### PR TITLE
Add missing tests for errors

### DIFF
--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -43,6 +43,12 @@ error WithdrawMoreThanMax(address owner, uint256 amount, uint256 max);
 /// @param max The max redeemable amount
 error RedeemMoreThanMax(address owner, uint256 amount, uint256 max);
 
+/// @notice Emitted when the amount of shares being minted to the receiver is greater than the max amount allowed
+/// @param receiver The receiver address
+/// @param shares The shares being minted
+/// @param max The max amount of shares that can be minted to the receiver
+error MintMoreThanMax(address receiver, uint256 shares, uint256 max);
+
 /// @notice Emitted during the liquidation process when the caller is not the liquidation pair contract
 /// @param caller The caller address
 /// @param liquidationPair The LP address
@@ -85,12 +91,6 @@ error YieldFeeGTAvailable(uint256 shares, uint256 yieldFeeTotalSupply);
 
 /// @notice Emitted when the Liquidation Pair being set is the zero address
 error LPZeroAddress();
-
-/// @notice Emitted when the amount of shares being minted to the receiver is greater than the max amount allowed
-/// @param receiver The receiver address
-/// @param shares The shares being minted
-/// @param max The max amount of shares that can be minted to the receiver
-error MintGTMax(address receiver, uint256 shares, uint256 max);
 
 /// @notice Emitted when the yield fee percentage being set is greater than 1
 /// @param yieldFeePercentage The yield fee percentage in integer format
@@ -962,7 +962,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
    * @return uint256 Amount of assets to deposit.
    */
   function _beforeMint(uint256 _shares, address _receiver) internal view returns (uint256) {
-    if (_shares > maxMint(_receiver)) revert MintGTMax(_receiver, _shares, maxMint(_receiver));
+    if (_shares > maxMint(_receiver)) revert MintMoreThanMax(_receiver, _shares, maxMint(_receiver));
     return _convertToAssets(_shares, Math.Rounding.Up);
   }
 

--- a/test/unit/Vault/Withdraw.t.sol
+++ b/test/unit/Vault/Withdraw.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.17;
 
 import { UnitBaseSetup, IERC20 } from "test/utils/UnitBaseSetup.t.sol";
+import { WithdrawMoreThanMax, RedeemMoreThanMax } from "src/Vault.sol";
 
 contract VaultWithdrawTest is UnitBaseSetup {
   /* ============ Events ============ */
@@ -42,6 +43,19 @@ contract VaultWithdrawTest is UnitBaseSetup {
     assertEq(yieldVault.balanceOf(address(vault)), 0);
     assertEq(underlyingAsset.balanceOf(address(yieldVault)), 0);
     assertEq(vault.totalSupply(), 0);
+
+    vm.stopPrank();
+  }
+
+  function testWithdrawMoreThanMax() external {
+    vm.startPrank(alice);
+
+    uint256 _amount = 1000e18;
+    underlyingAsset.mint(alice, _amount);
+    _deposit(underlyingAsset, vault, _amount, alice);
+
+    vm.expectRevert(abi.encodeWithSelector(WithdrawMoreThanMax.selector, alice, _amount + 1, _amount));
+    vault.withdraw(_amount + 1, alice, alice);
 
     vm.stopPrank();
   }
@@ -171,6 +185,19 @@ contract VaultWithdrawTest is UnitBaseSetup {
     assertEq(underlyingAsset.balanceOf(address(yieldVault)), 0);
     assertEq(yieldVault.balanceOf(address(vault)), 0);
     assertEq(vault.totalSupply(), 0);
+
+    vm.stopPrank();
+  }
+
+  function testRedeemMoreThanMax() external {
+    vm.startPrank(alice);
+
+    uint256 _amount = 1000e18;
+    underlyingAsset.mint(alice, _amount);
+    uint256 _shares = _deposit(underlyingAsset, vault, _amount, alice);
+
+    vm.expectRevert(abi.encodeWithSelector(RedeemMoreThanMax.selector, alice, _shares + 1, _shares));
+    vault.redeem(_shares + 1, alice, alice);
 
     vm.stopPrank();
   }


### PR DESCRIPTION
- Added missing tests for revert statements that had missing branches in coverage tests
    - Some branches are still reported as not covered, but the lines they are on seem fully tested
- Also renamed `MintGTMax` error to `MintMoreThanMax` to match the other errors