### PR TITLE
fix(Vault): use SafeCast for uint96 casts (c4-issue-439) 

### DIFF
--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import { ERC4626, ERC20, IERC20, IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
 import { ERC20Permit, IERC20Permit } from "openzeppelin/token/ERC20/extensions/draft-ERC20Permit.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import { SafeCast } from "openzeppelin/utils/math/SafeCast.sol";
 import { Math } from "openzeppelin/utils/math/Math.sol";
 import { Ownable } from "owner-manager-contracts/Ownable.sol";
 
@@ -109,6 +110,7 @@ error YieldFeePercentageGTPrecision(uint256 yieldFeePercentage, uint256 maxYield
  */
 contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
   using Math for uint256;
+  using SafeCast for uint256;
   using SafeERC20 for IERC20;
 
   /* ============ Events ============ */
@@ -232,7 +234,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
   /// @notice Fee precision denominated in 9 decimal places and used to calculate yield fee percentage.
   uint256 private constant FEE_PRECISION = 1e9;
 
-  /// @notice Maps user addresses to hooks that they want to execute when prizes are won
+  /// @notice Maps user addresses to hooks that they want to execute when prizes are won.
   mapping(address => VaultHooks) internal _hooks;
 
   /* ============ Constructor ============ */
@@ -651,8 +653,8 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
   }
 
   /**
-   * @notice Sets the hooks for a winner
-   * @param hooks The hooks to set.
+   * @notice Sets the hooks for a winner.
+   * @param hooks The hooks to set
    */
   function setHooks(VaultHooks memory hooks) external {
     _hooks[msg.sender] = hooks;
@@ -783,7 +785,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
   }
 
   /**
-   * @notice Gets the hooks for the given user
+   * @notice Gets the hooks for the given user.
    * @param _account The user to retrieve the hooks for
    * @return VaultHooks The hooks for the given user
    */
@@ -1053,6 +1055,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
   ) internal returns (uint256) {
     VaultHooks memory hooks = _hooks[_winner];
     address recipient;
+
     if (hooks.useBeforeClaimPrize) {
       recipient = hooks.implementation.beforeClaimPrize(_winner, _tier, _prizeIndex);
     } else {
@@ -1124,7 +1127,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
    * @dev Updates the exchange rate.
    */
   function _mint(address _receiver, uint256 _shares) internal virtual override {
-    _twabController.mint(_receiver, uint96(_shares));
+    _twabController.mint(_receiver, SafeCast.toUint96(_shares));
     _updateExchangeRate();
 
     emit Transfer(address(0), _receiver, _shares);
@@ -1140,7 +1143,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
    * @dev Updates the exchange rate.
    */
   function _burn(address _owner, uint256 _shares) internal virtual override {
-    _twabController.burn(_owner, uint96(_shares));
+    _twabController.burn(_owner, SafeCast.toUint96(_shares));
     _updateExchangeRate();
 
     emit Transfer(_owner, address(0), _shares);
@@ -1156,7 +1159,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
    * @dev `_from` must have a balance of at least `_shares`.
    */
   function _transfer(address _from, address _to, uint256 _shares) internal virtual override {
-    _twabController.transfer(_from, _to, uint96(_shares));
+    _twabController.transfer(_from, _to, SafeCast.toUint96(_shares));
 
     emit Transfer(_from, _to, _shares);
   }

--- a/test/unit/Vault/Deposit.feature
+++ b/test/unit/Vault/Deposit.feature
@@ -57,7 +57,8 @@ Feature: Deposit
     Then the YieldVault must mint to the Vault an amount of shares equivalent to the amount of underlying assets deposited
     Then the Vault `totalSupply` must be equal to 1,000
 
-  # Deposit - Inflation attack
+  # Deposit - Attacks
+  # Inflation attack
   Scenario: Bob front runs Alice deposits into the Vault
     Given Alice owns 0 Vault shares
     When Alice deposits 10,000 underlying assets but Bob front run by depositing 1 wei of underlying assets and transferring 1,000 underlying assets to the Vault

--- a/test/unit/Vault/Deposit.t.sol
+++ b/test/unit/Vault/Deposit.t.sol
@@ -187,6 +187,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
     vm.stopPrank();
   }
 
+  /* ============ Deposit - Attacks ============ */
   function testFailDepositInflationAttack() external {
     vm.startPrank(bob);
 
@@ -533,7 +534,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
     underlyingAsset.approve(address(vault), type(uint256).max);
 
     twabController.delegate(address(vault), twabController.SPONSORSHIP_ADDRESS());
-    
+
     vm.expectEmit();
     emit Transfer(address(0), alice, _amount);
 

--- a/test/unit/Vault/Withdraw.feature
+++ b/test/unit/Vault/Withdraw.feature
@@ -43,6 +43,12 @@ Feature: Withdraw
     Then the YieldVault balance of underlying assets must be equal to 0
     Then the Vault `totalSupply` must be equal to 0
 
+  # Withdraw - Attacks
+  Scenario: Bob tries to withdraw more than uint96 to exploit a rounding down error
+    Given Bob owns double the max amount that fits in uint96 Vault shares
+    When Bob `withdraw` his full deposit
+    Then it reverts with the error "SafeCast: value doesn't fit in 96 bits"
+
   # Redeem
   Scenario: Alice redeems her full deposit
     Given Alice owns 1,000 Vault shares

--- a/test/unit/Vault/Withdraw.t.sol
+++ b/test/unit/Vault/Withdraw.t.sol
@@ -159,6 +159,37 @@ contract VaultWithdrawTest is UnitBaseSetup {
     vm.stopPrank();
   }
 
+  /* ============ Withdraw - Attacks ============ */
+  function testWithdrawOverflow() external {
+    uint256 _amount = type(uint96).max;
+    uint256 _doubleAmount = _amount * 2;
+
+    vm.startPrank(bob);
+
+    underlyingAsset.mint(bob, _doubleAmount);
+    underlyingAsset.approve(address(vault), _doubleAmount);
+
+    // Need to deposit in two steps cause it would overflow over the maxDeposit limit of uint96 otherwise
+    // NOTE: this is only possible cause balances are stored in uint112 in the TwabController, it would revert if it was uint96
+    vault.deposit(_amount, bob);
+    vault.deposit(_amount, bob);
+
+    assertEq(vault.balanceOf(bob), _doubleAmount);
+
+    assertEq(twabController.balanceOf(address(vault), bob), _doubleAmount);
+    assertEq(twabController.delegateBalanceOf(address(vault), bob), _doubleAmount);
+
+    assertEq(underlyingAsset.balanceOf(address(yieldVault)), _doubleAmount);
+    assertEq(yieldVault.balanceOf(address(vault)), _doubleAmount);
+    assertEq(yieldVault.totalSupply(), _doubleAmount);
+
+    uint256 _bobMaxWithdraw = vault.maxWithdraw(bob);
+    assertEq(_bobMaxWithdraw, _doubleAmount);
+
+    vm.expectRevert(bytes("SafeCast: value doesn't fit in 96 bits"));
+    vault.withdraw(_bobMaxWithdraw, bob, bob);
+  }
+
   /* ============ Redeem ============ */
   function testRedeemFullAmount() external {
     vm.startPrank(alice);


### PR DESCRIPTION
Issue: https://github.com/code-423n4/2023-07-pooltogether-findings/issues/439