### PR TITLE
[C4-384 : QA-04] switch safeApproval to safeIncreaseAllowance

### DIFF
--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import { ERC4626, ERC20, IERC20, IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
-import { ERC20Permit, IERC20Permit } from "openzeppelin/token/ERC20/extensions/draft-ERC20Permit.sol";
+import { ERC20Permit, IERC20Permit } from "openzeppelin/token/ERC20/extensions/ERC20Permit.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { SafeCast } from "openzeppelin/utils/math/SafeCast.sol";
 import { Math } from "openzeppelin/utils/math/Math.sol";
@@ -343,7 +343,7 @@ contract Vault is ERC4626, ERC20Permit, ILiquidationSource, Ownable {
     _setYieldFeePercentage(yieldFeePercentage_);
 
     // Approve once for max amount
-    asset_.safeApprove(address(yieldVault_), type(uint256).max);
+    asset_.safeIncreaseAllowance(address(yieldVault_), type(uint256).max);
 
     emit NewVault(
       asset_,


### PR DESCRIPTION
Also update ERC20Permit.sol import path to not use the draft path.

fixes: https://github.com/code-423n4/2023-07-pooltogether-findings/blob/main/data/Bauchibred-Q.md#qa-04---safeapprove-is-deprecated-and-should-not-be-used-when-possible