### PR TITLE
Update coverage.yml PR permissions to 'write'

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,8 @@ jobs:
   forge:
     strategy:
       fail-fast: true
-
+    permissions:
+      pull-requests: write
     name: Foundry project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Allows lcov to comment results to the PR without failing the action.