### PR TITLE
fix(Vault): switch from public to external functions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Forge gas report
         run: forge test --gas-report
-        id: snapshot
+        id: gas
 
       - name: Install lcov
         uses: hrishikesh-kadam/setup-lcov@v1.0.0

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -16,9 +16,6 @@ import { TwabController, SPONSORSHIP_ADDRESS } from "pt-v5-twab-controller/TwabC
 import { IClaimable } from "pt-v5-claimable-interface/interfaces/IClaimable.sol";
 import { VaultHooks } from "./interfaces/IVaultHooks.sol";
 
-// The maximum amount of shares that can be minted.
-uint256 constant UINT112_MAX = type(uint112).max;
-
 /**
  * @title  PoolTogether V5 Vault
  * @author PoolTogether Inc Team, Generation Software Team
@@ -35,6 +32,9 @@ contract Vault is IERC4626, ERC20Permit, ILiquidationSource, IClaimable, Ownable
   using SafeERC20 for IERC20;
 
   /* ============ Variables ============ */
+
+  /// The maximum amount of shares that can be minted.
+  uint256 constant UINT112_MAX = type(uint112).max;
 
   /// @notice Address of the underlying asset used by the Vault.
   IERC20 private immutable _asset;

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -1239,7 +1239,6 @@ contract Vault is IERC4626, ERC20Permit, ILiquidationSource, IClaimable, Ownable
    *      - if `_vaultAssets` balance is greater than or equal to `_assets`,
    *        we know the vault has enough underlying assets to fulfill the deposit
    *        so we don't transfer any assets from the user wallet into the vault
-   * @dev Will revert if the Vault is undercollateralized.
    * @dev Will revert if 0 shares are minted back to the receiver.
    */
   function _deposit(address _caller, address _receiver, uint256 _assets) internal {

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -1194,7 +1194,7 @@ contract Vault is IERC4626, ERC20Permit, ILiquidationSource, IClaimable, Ownable
       _depositedAssets + _yieldFeeShares,
       _depositedAssets,
       _withdrawableAssets,
-      Math.Rounding.Down
+      Math.Rounding.Up
     );
 
     return _assetsAllocated > _withdrawableAssets ? 0 : _withdrawableAssets - _assetsAllocated;

--- a/test/contracts/mock/LiquidationPairMock.sol
+++ b/test/contracts/mock/LiquidationPairMock.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 
 import { ILiquidationSource } from "pt-v5-liquidator-interfaces/ILiquidationSource.sol";

--- a/test/contracts/mock/YieldVault.sol
+++ b/test/contracts/mock/YieldVault.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
-import { ERC4626Mock, IERC20, IERC20Metadata } from "openzeppelin/mocks/ERC4626Mock.sol";
+import { ERC4626Mock } from "openzeppelin/mocks/ERC4626Mock.sol";
 import { Math } from "openzeppelin/utils/math/Math.sol";
 
 contract YieldVault is ERC4626Mock {

--- a/test/fuzz/Vault.t.sol
+++ b/test/fuzz/Vault.t.sol
@@ -13,7 +13,6 @@ import { TwabController } from "pt-v5-twab-controller/TwabController.sol";
 
 import { Vault } from "../../src/Vault.sol";
 
-import { ERC20PermitMock } from "../contracts/mock/ERC20PermitMock.sol";
 import { LiquidationPairMock } from "../contracts/mock/LiquidationPairMock.sol";
 import { LiquidationRouterMock } from "../contracts/mock/LiquidationRouterMock.sol";
 import { PrizePoolMock } from "../contracts/mock/PrizePoolMock.sol";

--- a/test/unit/Vault/Deposit.feature
+++ b/test/unit/Vault/Deposit.feature
@@ -68,7 +68,7 @@ Feature: Deposit
   Scenario: Alice deposits into the Vault
     Given Alice owns 0 Vault shares and the Vault is undercollateralized
     When Alice deposits 1,000 underlying assets
-    Then the transaction reverts with the custom error `VaultUnderCollateralized`
+    Then the transaction reverts with the custom error `VaultUndercollateralized`
 
   # Deposit - Attacks
   # Inflation attack
@@ -111,7 +111,7 @@ Feature: Deposit
   Scenario: Alice mints shares from the Vault
     Given Alice owns 0 Vault shares
     When Alice mints type(uint112).max + 1 shares
-    Then the transaction reverts with the error SafeCast: value doesn't fit in 112 bits
+    Then the transaction reverts with the custom error `MintMoreThanMax`
 
   Scenario: Alice mints shares from the Vault
     Given Alice owns 0 Vault shares and YieldVault's maxMint function returns type(uint88).max
@@ -126,7 +126,7 @@ Feature: Deposit
   Scenario: Alice mints 1,000 shares from the Vault
     Given Alice owns 0 Vault shares and the Vault is undercollateralized
     When Alice mints 1,000 shares
-    Then the transaction reverts with the custom error VaultUnderCollateralized
+    Then the transaction reverts with the custom error VaultUndercollateralized
 
   # Sponsor
   Scenario: Alice sponsors the Vault

--- a/test/unit/Vault/Deposit.t.sol
+++ b/test/unit/Vault/Deposit.t.sol
@@ -191,7 +191,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
     underlyingAsset.approve(address(vault), type(uint256).max);
 
     vm.expectRevert(
-      abi.encodeWithSelector(DepositMoreThanMax.selector, alice, _amount, type(uint112).max)
+      abi.encodeWithSelector(Vault.DepositMoreThanMax.selector, alice, _amount, type(uint112).max)
     );
 
     vault.deposit(_amount, alice);
@@ -214,7 +214,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
     );
 
     vm.expectRevert(
-      abi.encodeWithSelector(DepositMoreThanMax.selector, alice, _amount, type(uint88).max)
+      abi.encodeWithSelector(Vault.DepositMoreThanMax.selector, alice, _amount, type(uint88).max)
     );
 
     vault.deposit(_amount, alice);
@@ -234,7 +234,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
 
     underlyingAsset.burn(address(yieldVault), _amount);
 
-    vm.expectRevert(abi.encodeWithSelector(VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
 
     vault.deposit(_amount, alice);
 
@@ -422,7 +422,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
   function testMintZeroShares() external {
     vm.startPrank(alice);
 
-    vm.expectRevert(abi.encodeWithSelector(MintZeroShares.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.MintZeroShares.selector));
 
     vault.mint(0, alice);
 
@@ -441,7 +441,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
 
     underlyingAsset.burn(address(yieldVault), _amount);
 
-    vm.expectRevert(abi.encodeWithSelector(VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
 
     vault.mint(_amount, alice);
 
@@ -552,7 +552,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
   function testSweepZeroAssets() external {
     vm.startPrank(bob);
 
-    vm.expectRevert(abi.encodeWithSelector(SweepZeroAssets.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.SweepZeroAssets.selector));
 
     vault.sweep();
 

--- a/test/unit/Vault/Deposit.t.sol
+++ b/test/unit/Vault/Deposit.t.sol
@@ -234,7 +234,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
 
     underlyingAsset.burn(address(yieldVault), _amount);
 
-    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUndercollateralized.selector));
 
     vault.deposit(_amount, alice);
 
@@ -389,7 +389,9 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
     underlyingAsset.mint(alice, _amount);
     underlyingAsset.approve(address(vault), type(uint256).max);
 
-    vm.expectRevert(bytes("SafeCast: value doesn't fit in 112 bits"));
+    vm.expectRevert(
+      abi.encodeWithSelector(Vault.MintMoreThanMax.selector, alice, _amount, type(uint112).max)
+    );
 
     vault.mint(_amount, alice);
 
@@ -441,7 +443,7 @@ contract VaultDepositTest is UnitBaseSetup, BrokenToken {
 
     underlyingAsset.burn(address(yieldVault), _amount);
 
-    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUndercollateralized.selector));
 
     vault.mint(_amount, alice);
 

--- a/test/unit/Vault/DepositBrokenToken.t.sol
+++ b/test/unit/Vault/DepositBrokenToken.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import { UnitBrokenTokenBaseSetup } from "../../utils/UnitBrokenTokenBaseSetup.t.sol";
-import { DepositMoreThanMax } from "../../../src/Vault.sol";
+import "../../../src/Vault.sol";
 
 contract VaultDepositBrokenTokenTest is UnitBrokenTokenBaseSetup {
   /* ============ Events ============ */
@@ -43,7 +43,7 @@ contract VaultDepositBrokenTokenTest is UnitBrokenTokenBaseSetup {
     // Token with 50 decimals, amount is greater than type(uint112).max
     if (brokenERC20Name == keccak256(bytes("HighDecimalToken"))) {
       vm.expectRevert(
-        abi.encodeWithSelector(DepositMoreThanMax.selector, alice, _amount, type(uint112).max)
+        abi.encodeWithSelector(Vault.DepositMoreThanMax.selector, alice, _amount, type(uint112).max)
       );
 
       vault.deposit(_amount, alice);

--- a/test/unit/Vault/Liquidate.feature
+++ b/test/unit/Vault/Liquidate.feature
@@ -58,7 +58,7 @@ Feature: Liquidate
   Scenario: Bob swaps prize tokens in exchange of Vault shares
     Given the YieldVault is now undercollateralized
     When `liquidate` is called
-    Then the transaction reverts with the custom error `VaultUnderCollateralized`
+    Then the transaction reverts with the custom error `VaultUndercollateralized`
 
   Scenario: Bob swaps prize tokens in exchange of Vault shares by calling `liquidate` directly
     Given no underlying assets have accrued in the YieldVault

--- a/test/unit/Vault/Liquidate.t.sol
+++ b/test/unit/Vault/Liquidate.t.sol
@@ -400,7 +400,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     vm.startPrank(address(liquidationPair));
 
-    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUndercollateralized.selector));
 
     vault.transferTokensOut(address(this), address(this), address(vault), 1e18);
 

--- a/test/unit/Vault/Liquidate.t.sol
+++ b/test/unit/Vault/Liquidate.t.sol
@@ -400,7 +400,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     vm.startPrank(address(liquidationPair));
 
-    vm.expectRevert(abi.encodeWithSelector(VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
 
     vault.transferTokensOut(address(this), address(this), address(vault), 1e18);
 
@@ -412,7 +412,9 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     vm.startPrank(bob);
 
-    vm.expectRevert(abi.encodeWithSelector(CallerNotLP.selector, bob, address(liquidationPair)));
+    vm.expectRevert(
+      abi.encodeWithSelector(Vault.CallerNotLP.selector, bob, address(liquidationPair))
+    );
 
     vault.transferTokensOut(address(this), address(this), address(vault), 1e18);
 
@@ -437,7 +439,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
     _setLiquidationPair();
 
     vm.expectRevert(
-      abi.encodeWithSelector(CallerNotLP.selector, address(bob), address(liquidationPair))
+      abi.encodeWithSelector(Vault.CallerNotLP.selector, address(bob), address(liquidationPair))
     );
 
     vm.startPrank(address(bob));
@@ -452,7 +454,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        LiquidationTokenInNotPrizeToken.selector,
+        Vault.LiquidationTokenInNotPrizeToken.selector,
         address(0),
         address(prizeToken)
       )
@@ -469,7 +471,11 @@ contract VaultLiquidateTest is UnitBaseSetup {
     vm.startPrank(address(liquidationPair));
 
     vm.expectRevert(
-      abi.encodeWithSelector(LiquidationTokenOutNotVaultShare.selector, address(0), address(vault))
+      abi.encodeWithSelector(
+        Vault.LiquidationTokenOutNotVaultShare.selector,
+        address(0),
+        address(vault)
+      )
     );
 
     vault.transferTokensOut(address(this), address(this), address(0), 0);
@@ -482,7 +488,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     vm.startPrank(address(liquidationPair));
 
-    vm.expectRevert(abi.encodeWithSelector(LiquidationAmountOutZero.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.LiquidationAmountOutZero.selector));
 
     vault.transferTokensOut(address(this), address(this), address(vault), 0);
 
@@ -495,7 +501,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
     vm.startPrank(address(liquidationPair));
 
     vm.expectRevert(
-      abi.encodeWithSelector(LiquidationAmountOutGTYield.selector, type(uint256).max, 0)
+      abi.encodeWithSelector(Vault.LiquidationAmountOutGTYield.selector, type(uint256).max, 0)
     );
 
     vault.transferTokensOut(address(this), address(this), address(vault), type(uint256).max);
@@ -543,7 +549,7 @@ contract VaultLiquidateTest is UnitBaseSetup {
 
     _accrueYield(underlyingAsset, yieldVault, 10e18);
 
-    vm.expectRevert(abi.encodeWithSelector(YieldFeeGTAvailableShares.selector, 10e18, 0));
+    vm.expectRevert(abi.encodeWithSelector(Vault.YieldFeeGTAvailableShares.selector, 10e18, 0));
     vault.mintYieldFee(10e18);
   }
 

--- a/test/unit/Vault/Undercollateralization.t.sol
+++ b/test/unit/Vault/Undercollateralization.t.sol
@@ -271,7 +271,7 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     // Bob can't withdraw any assets
     assertEq(_bobMaxWithdraw, 0);
 
-    vm.expectRevert(abi.encodeWithSelector(WithdrawZeroAssets.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.WithdrawZeroAssets.selector));
 
     vault.withdraw(_bobMaxWithdraw, bob, bob);
 
@@ -284,14 +284,14 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     // Alice can't withdraw any assets
     assertEq(_aliceMaxWithdraw, 0);
 
-    vm.expectRevert(abi.encodeWithSelector(WithdrawZeroAssets.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.WithdrawZeroAssets.selector));
 
     vault.withdraw(_aliceMaxWithdraw, alice, alice);
 
     underlyingAsset.mint(alice, _aliceAmount);
 
     // Alice can't deposit into an undercollateralized vault
-    vm.expectRevert(abi.encodeWithSelector(VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
 
     vault.deposit(_aliceAmount, alice);
 
@@ -407,7 +407,7 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     uint256 _yieldFeeShares = vault.yieldFeeShares();
 
     // The Vault is now undercollateralized so we can't mint the yield fee
-    vm.expectRevert(abi.encodeWithSelector(VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
     vault.mintYieldFee(_yieldFeeShares);
 
     vm.startPrank(bob);
@@ -494,7 +494,7 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     // The Vault is now partially undercollateralized so we can't mint the yield fee
     vm.expectRevert(
       abi.encodeWithSelector(
-        YieldFeeGTAvailableYield.selector,
+        Vault.YieldFeeGTAvailableYield.selector,
         vault.convertToAssets(_yieldFeeShares),
         yieldVault.maxWithdraw(address(vault)) - vault.convertToAssets(vault.totalSupply())
       )

--- a/test/unit/Vault/Undercollateralization.t.sol
+++ b/test/unit/Vault/Undercollateralization.t.sol
@@ -291,7 +291,7 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     underlyingAsset.mint(alice, _aliceAmount);
 
     // Alice can't deposit into an undercollateralized vault
-    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUndercollateralized.selector));
 
     vault.deposit(_aliceAmount, alice);
 
@@ -407,7 +407,7 @@ contract VaultUndercollateralizationTest is UnitBaseSetup {
     uint256 _yieldFeeShares = vault.yieldFeeShares();
 
     // The Vault is now undercollateralized so we can't mint the yield fee
-    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUnderCollateralized.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.VaultUndercollateralized.selector));
     vault.mintYieldFee(_yieldFeeShares);
 
     vm.startPrank(bob);

--- a/test/unit/Vault/Vault.t.sol
+++ b/test/unit/Vault/Vault.t.sol
@@ -75,7 +75,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testConstructorYieldVaultZero() external {
-    vm.expectRevert(abi.encodeWithSelector(YieldVaultZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.YieldVaultZeroAddress.selector));
 
     new Vault(
       IERC20(address(underlyingAsset)),
@@ -91,7 +91,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testConstructorPrizePoolZero() external {
-    vm.expectRevert(abi.encodeWithSelector(PrizePoolZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.PrizePoolZeroAddress.selector));
 
     new Vault(
       IERC20(address(underlyingAsset)),
@@ -107,7 +107,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testConstructorOwnerZero() external {
-    vm.expectRevert(abi.encodeWithSelector(OwnerZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.OwnerZeroAddress.selector));
 
     new Vault(
       IERC20(address(underlyingAsset)),
@@ -130,7 +130,11 @@ contract VaultTest is UnitBaseSetup {
     );
 
     vm.expectRevert(
-      abi.encodeWithSelector(UnderlyingAssetMismatch.selector, address(underlyingAsset), address(0))
+      abi.encodeWithSelector(
+        Vault.UnderlyingAssetMismatch.selector,
+        address(underlyingAsset),
+        address(0)
+      )
     );
 
     new Vault(
@@ -147,7 +151,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testConstructorClaimerZero() external {
-    vm.expectRevert(abi.encodeWithSelector(ClaimerZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.ClaimerZeroAddress.selector));
 
     new Vault(
       IERC20(address(underlyingAsset)),
@@ -251,7 +255,7 @@ contract VaultTest is UnitBaseSetup {
 
     mockPrizePoolClaimPrize(uint8(1), alice, 0, 0, address(0));
     vm.expectRevert(
-      abi.encodeWithSelector(CallerNotClaimer.selector, _randomUser, address(claimer))
+      abi.encodeWithSelector(Vault.CallerNotClaimer.selector, _randomUser, address(claimer))
     );
 
     claimPrize(uint8(1), alice, 0, 0, address(0));
@@ -262,7 +266,7 @@ contract VaultTest is UnitBaseSetup {
   function testClaimPrizeCallerNotClaimer() public {
     vm.startPrank(alice);
 
-    vm.expectRevert(abi.encodeWithSelector(CallerNotClaimer.selector, alice, claimer));
+    vm.expectRevert(abi.encodeWithSelector(Vault.CallerNotClaimer.selector, alice, claimer));
     vault.claimPrize(alice, uint8(1), uint32(0), uint96(0), address(0));
 
     vm.stopPrank();
@@ -291,7 +295,7 @@ contract VaultTest is UnitBaseSetup {
 
     mockPrizePoolClaimPrize(uint8(1), alice, 0, bob, 1e18, address(claimer));
 
-    vm.expectRevert(abi.encodeWithSelector(ClaimRecipientZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.ClaimRecipientZeroAddress.selector));
     claimPrize(uint8(1), alice, 0, 1e18, address(claimer));
 
     vm.stopPrank();
@@ -356,7 +360,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testSetClaimerZeroAddress() public {
-    vm.expectRevert(abi.encodeWithSelector(ClaimerZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.ClaimerZeroAddress.selector));
     vault.setClaimer(address(0));
   }
 
@@ -372,7 +376,7 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testSetLiquidationPairNotZeroAddress() public {
-    vm.expectRevert(abi.encodeWithSelector(LPZeroAddress.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.LPZeroAddress.selector));
     vault.setLiquidationPair(ILiquidationPair(address(0)));
   }
 
@@ -399,7 +403,9 @@ contract VaultTest is UnitBaseSetup {
   }
 
   function testSetYieldFeePercentageGT1e9() public {
-    vm.expectRevert(abi.encodeWithSelector(YieldFeePercentageGtePrecision.selector, 2e9, 1e9));
+    vm.expectRevert(
+      abi.encodeWithSelector(Vault.YieldFeePercentageGtePrecision.selector, 2e9, 1e9)
+    );
     vault.setYieldFeePercentage(2e9);
   }
 

--- a/test/unit/Vault/Withdraw.t.sol
+++ b/test/unit/Vault/Withdraw.t.sol
@@ -240,7 +240,7 @@ contract VaultWithdrawTest is UnitBaseSetup {
     _deposit(underlyingAsset, vault, _amount, alice);
 
     vm.expectRevert(
-      abi.encodeWithSelector(WithdrawMoreThanMax.selector, alice, _amount + 1, _amount)
+      abi.encodeWithSelector(Vault.WithdrawMoreThanMax.selector, alice, _amount + 1, _amount)
     );
 
     vault.withdraw(_amount + 1, alice, alice);
@@ -251,7 +251,7 @@ contract VaultWithdrawTest is UnitBaseSetup {
   function testWithdrawZeroAssets() external {
     vm.startPrank(alice);
 
-    vm.expectRevert(abi.encodeWithSelector(WithdrawZeroAssets.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.WithdrawZeroAssets.selector));
 
     vault.withdraw(0, alice, alice);
 
@@ -403,7 +403,7 @@ contract VaultWithdrawTest is UnitBaseSetup {
     uint256 _shares = _deposit(underlyingAsset, vault, _amount, alice);
 
     vm.expectRevert(
-      abi.encodeWithSelector(RedeemMoreThanMax.selector, alice, _shares + 1, _shares)
+      abi.encodeWithSelector(Vault.RedeemMoreThanMax.selector, alice, _shares + 1, _shares)
     );
     vault.redeem(_shares + 1, alice, alice);
 
@@ -413,7 +413,7 @@ contract VaultWithdrawTest is UnitBaseSetup {
   function testRedeemZeroShares() external {
     vm.startPrank(alice);
 
-    vm.expectRevert(abi.encodeWithSelector(WithdrawZeroAssets.selector));
+    vm.expectRevert(abi.encodeWithSelector(Vault.WithdrawZeroAssets.selector));
 
     vault.redeem(0, alice, alice);
 

--- a/test/unit/Vault/Withdraw.t.sol
+++ b/test/unit/Vault/Withdraw.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import { UnitBaseSetup, IERC20 } from "../../utils/UnitBaseSetup.t.sol";
-import "../../../src/Vault.sol";
+import { Vault } from "../../../src/Vault.sol";
 
 contract VaultWithdrawTest is UnitBaseSetup {
   /* ============ Events ============ */

--- a/test/unit/VaultFactory.t.sol
+++ b/test/unit/VaultFactory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-import "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
 import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
 import { IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";

--- a/test/utils/Helpers.t.sol
+++ b/test/utils/Helpers.t.sol
@@ -8,13 +8,10 @@ import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { IERC20Permit } from "openzeppelin/token/ERC20/extensions/draft-ERC20Permit.sol";
 import { Math } from "openzeppelin/utils/math/Math.sol";
 
-import { PrizePool } from "pt-v5-prize-pool/PrizePool.sol";
-
 import { IERC4626, Vault } from "../../src/Vault.sol";
 
 import { LiquidationPairMock } from "../contracts/mock/LiquidationPairMock.sol";
 import { LiquidationRouterMock } from "../contracts/mock/LiquidationRouterMock.sol";
-import { PrizePoolMock } from "../contracts/mock/PrizePoolMock.sol";
 import { YieldVault } from "../contracts/mock/YieldVault.sol";
 
 contract Helpers is Test {

--- a/test/utils/UnitBrokenTokenBaseSetup.t.sol
+++ b/test/utils/UnitBrokenTokenBaseSetup.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-import { ERC20, IERC20, IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
 import { BrokenToken } from "brokentoken/BrokenToken.sol";
 
 import { ERC20PermitMock } from "../contracts/mock/ERC20PermitMock.sol";

--- a/test/utils/Utils.t.sol
+++ b/test/utils/Utils.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.19;
 
-import "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
 contract Utils is Test {
   // Move block.number forward by a given number of blocks


### PR DESCRIPTION
Changes:
- public functions have been transformed into external functions
- code has been reorganized to follow the official guidelines: https://docs.soliditylang.org/en/latest/style-guide.html#order-of-layout
- custom error MintMoreThanMax has been added