### PR TITLE
Simplify yield fee

### DIFF
--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -191,7 +191,7 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
      * @param totalToWithdraw The total yield to withdraw
      * @param availableYield The available yield
      */
-    error LiquidationGtAvailable(uint256 totalToWithdraw, uint256 availableYield);
+    error LiquidationExceedsAvailable(uint256 totalToWithdraw, uint256 availableYield);
 
     /* ============ Modifiers ============ */
 
@@ -522,7 +522,7 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
         // Ensure total withdrawn does not exceed the available yield balance:
         uint256 _totalToWithdraw = _amountOut + _yieldFee;
         if (_totalToWithdraw > _availableYieldBalance) {
-            revert LiquidationGtAvailable(_totalToWithdraw, _availableYieldBalance);
+            revert LiquidationExceedsAvailable(_totalToWithdraw, _availableYieldBalance);
         }
 
         _withdraw(address(this), _totalToWithdraw);

--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -36,6 +36,13 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
 
     /// @notice The yield fee decimal precision.
     uint32 public constant FEE_PRECISION = 1e9;
+    
+    /// @notice The max yield fee that can be set.
+    /// @dev Decimal precision is defined by `FEE_PRECISION`.
+    /// @dev If the yield fee is set too high, liquidations won't occur on a regular basis. If a use case requires
+    ///      a yield fee higher than this max, a custom liquidation pair can be set to manipulate the yield as
+    ///      required.
+    uint32 public constant MAX_YIELD_FEE = 9e8;
 
     /// @notice The yield buffer that is reserved for covering rounding errors on withdrawals and deposits.
     /// @dev The buffer prevents the entire yield balance from being liquidated, which would leave the vault in a
@@ -65,9 +72,6 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
 
     /// @notice Underlying asset decimals.
     uint8 private immutable _underlyingDecimals;
-
-    /// @notice Yield fees accrued through liquidations.
-    uint256 private _accruedYieldFee;
 
     /* ============ Events ============ */
 
@@ -152,13 +156,6 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     error PermitCallerNotOwner(address caller, address owner);
 
     /**
-     * @notice Thrown when the caller that is withdrawing the yield fee is not the fee recipient.
-     * @param caller The caller address
-     * @param yieldFeeRecipient The yield fee recipient address
-     */
-    error CallerNotYieldFeeRecipient(address caller, address yieldFeeRecipient);
-
-    /**
      * @notice Thrown when a permit call on the underlying asset failed to set the spending allowance.
      * @dev This is likely thrown when the underlying asset does not support permit, but has a fallback function.
      * @param owner The owner of the assets
@@ -169,11 +166,11 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     error PermitAllowanceNotSet(address owner, address spender, uint256 amount, uint256 allowance);
 
     /**
-     * @notice Thrown when the yield fee percentage being set is greater than 100%.
+     * @notice Thrown when the yield fee percentage being set exceeds the max yield fee allowed.
      * @param yieldFeePercentage The yield fee percentage in integer format
-     * @param maxYieldFeePercentage The max yield fee percentage in integer format (this value is equal to 1 in decimal format)
+     * @param maxYieldFeePercentage The max yield fee percentage in integer format
      */
-    error YieldFeePercentageGtPrecision(uint256 yieldFeePercentage, uint256 maxYieldFeePercentage);
+    error YieldFeePercentageExceedsMax(uint256 yieldFeePercentage, uint256 maxYieldFeePercentage);
 
     /**
      * @notice Thrown during the liquidation process when the token in is not the prize token.
@@ -183,13 +180,6 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     error LiquidationTokenInNotPrizeToken(address tokenIn, address prizeToken);
 
     /**
-     * @notice Thrown when the fee being withdrawn exceeds the available yield fee balance.
-     * @param amount The fee being withdrawn
-     * @param yieldFeeBalance The available yield fee balance
-     */
-    error AmountExceedsYieldFeeBalance(uint256 amount, uint256 yieldFeeBalance);
-
-    /**
      * @notice Thrown during the liquidation process when the token out is not the vault asset.
      * @param tokenOut The provided tokenOut address
      * @param vaultAsset The vault asset address
@@ -197,11 +187,11 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     error LiquidationTokenOutNotAsset(address tokenOut, address vaultAsset);
 
     /**
-     * @notice Thrown during the liquidation process if the amount out is greater than the available yield.
-     * @param amountOut The amount out
+     * @notice Thrown during the liquidation process if the total to withdraw is greater than the available yield.
+     * @param totalToWithdraw The total yield to withdraw
      * @param availableYield The available yield
      */
-    error LiquidationAmountOutGtYield(uint256 amountOut, uint256 availableYield);
+    error LiquidationGtAvailable(uint256 totalToWithdraw, uint256 availableYield);
 
     /* ============ Modifiers ============ */
 
@@ -209,14 +199,6 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     modifier onlyLiquidationPair() {
         if (msg.sender != liquidationPair) {
             revert CallerNotLP(msg.sender, liquidationPair);
-        }
-        _;
-    }
-
-    /// @notice Requires the caller to be the yield fee recipient.
-    modifier onlyYieldFeeRecipient() {
-        if (msg.sender != yieldFeeRecipient) {
-            revert CallerNotYieldFeeRecipient(msg.sender, yieldFeeRecipient);
         }
         _;
     }
@@ -499,43 +481,6 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
         }
     }
 
-    /**
-     * @notice The available yield fee balance that can be withdrawn by the fee recipient.
-     * @dev Returns the full excess asset balance if the fee percentage has been set to
-     * 100%. This enables LPs to be bypassed on 100% fee vaults.
-     * @dev Limits the accrued fee to the amount of excess assets available in the vault.
-     * This ensures that the yield fee is used to make depositors whole in the case of an
-     * asset shortage.
-     * @return The accrued yield fee balance.
-     */
-    function yieldFeeBalance() public view returns (uint256) {
-        uint256 _availableYieldBalance = availableYieldBalance();
-        if (yieldFeePercentage == FEE_PRECISION) {
-            return _availableYieldBalance;
-        } else {
-            return _accruedYieldFee >= _availableYieldBalance ? _availableYieldBalance : _accruedYieldFee;
-        }
-    }
-
-    /**
-     * @notice Withdraws the yield fee to the yield fee recipient.
-     * @dev Will revert if the caller is not the recipient.
-     * @dev Will revert if the entire amount cannot be withdrawn due to yield vault limits.
-     * @dev Will revert if the amount exceeds the available fee balance.
-     */
-    function withdrawYieldFee(uint256 _amount) external onlyYieldFeeRecipient {
-        uint256 _yieldFeeBalance = yieldFeeBalance();
-
-        if (_amount > _yieldFeeBalance) revert AmountExceedsYieldFeeBalance(_amount, _yieldFeeBalance);
-        
-        unchecked {
-            _accruedYieldFee = _yieldFeeBalance - _amount;
-        }
-        _withdraw(yieldFeeRecipient, _amount);
-
-        emit WithdrawYieldFee(msg.sender, _amount);
-    }
-
     /* ============ LiquidationSource Functions ============ */
 
     /// @inheritdoc ILiquidationSource
@@ -544,11 +489,10 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
         if (_token != address(_asset)) {
             return 0;
         } else {
-            // TODO: Add rounding error explanation for subtracting yield buffer from the available yield balance.
-            uint256 _maxLiquidation = availableYieldBalance() - _accruedYieldFee;
-            uint256 _maxLiquidationMinusFees = _maxLiquidation - (_maxLiquidation * yieldFeePercentage) / FEE_PRECISION;
+            uint256 _availableYieldBalance = availableYieldBalance();
             uint256 _maxWithdraw = yieldVault.maxWithdraw(address(this));
-            return _maxWithdraw < _maxLiquidationMinusFees ? _maxWithdraw : _maxLiquidationMinusFees;
+            uint256 _withdrawableYieldBalance = _availableYieldBalance >= _maxWithdraw ? _maxWithdraw : _availableYieldBalance;
+            return _withdrawableYieldBalance * (FEE_PRECISION - yieldFeePercentage) / FEE_PRECISION;
         }
     }
 
@@ -562,24 +506,30 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
         if (_tokenOut != address(_asset)) {
             revert LiquidationTokenOutNotAsset(_tokenOut, address(_asset));
         }
+
+        uint32 _yieldFeePercentage = yieldFeePercentage;
         if (_amountOut == 0) revert LiquidationAmountOutZero();
 
-        uint256 _liquidatableYield = liquidatableBalanceOf(_tokenOut);
-        uint32 _yieldFeePercentage = yieldFeePercentage;
+        uint256 _availableYieldBalance = availableYieldBalance();
+        address _yieldFeeRecipient = yieldFeeRecipient;
 
-        if (_amountOut > _liquidatableYield) {
-            revert LiquidationAmountOutGtYield(_amountOut, _liquidatableYield);
+        // Determine the proportional yield fee based on the amount being liquidated:
+        uint256 _yieldFee;
+        if (_yieldFeePercentage != 0 && _yieldFeeRecipient != address(0)) {
+            _yieldFee = (_amountOut * FEE_PRECISION) / (FEE_PRECISION - _yieldFeePercentage) - _amountOut;
         }
 
-        // Distributes the specified yield fee percentage.
-        // For instance, with a yield fee percentage of 20% and 8e18 assets being liquidated,
-        // this calculation assigns 2e18 assets to the yield fee recipient.
-        // `_amountOut` is the amount of assets being liquidated after accounting for the yield fee.
-        if (_yieldFeePercentage != 0) {
-            _accruedYieldFee += (_amountOut * FEE_PRECISION) / (FEE_PRECISION - _yieldFeePercentage) - _amountOut;
+        // Ensure total withdrawn does not exceed the available yield balance:
+        uint256 _totalToWithdraw = _amountOut + _yieldFee;
+        if (_totalToWithdraw > _availableYieldBalance) {
+            revert LiquidationGtAvailable(_totalToWithdraw, _availableYieldBalance);
         }
 
-        _withdraw(_receiver, _amountOut);
+        _withdraw(address(this), _totalToWithdraw);
+        _asset.transfer(_receiver, _amountOut);
+        if (_yieldFee > 0) {
+            _asset.transfer(_yieldFeeRecipient, _yieldFee);
+        }
 
         return "";
     }
@@ -758,17 +708,19 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
             uint256 _yieldVaultShares = yieldVault.previewWithdraw(_assets - _latentAssets); // should include any fees and round up, so the following redeem call should return enough assets
             yieldVault.redeem(_yieldVaultShares, address(this), address(this)); // send assets to this contract so any leftover dust can be redeposited later
         }
-        _asset.transfer(_receiver, _assets);
+        if (_receiver != address(this)) {
+            _asset.transfer(_receiver, _assets);
+        }
     }
 
     /**
      * @notice Set yield fee percentage.
-     * @dev Yield fee is defined on a scale from `0` to `FEE_PRECISION`, inclusive.
+     * @dev Yield fee is defined on a scale from `0` to `MAX_YIELD_FEE`, inclusive.
      * @param _yieldFeePercentage The new yield fee percentage to set
      */
     function _setYieldFeePercentage(uint32 _yieldFeePercentage) internal {
-        if (_yieldFeePercentage > FEE_PRECISION) {
-            revert YieldFeePercentageGtPrecision(_yieldFeePercentage, FEE_PRECISION);
+        if (_yieldFeePercentage > MAX_YIELD_FEE) {
+            revert YieldFeePercentageExceedsMax(_yieldFeePercentage, MAX_YIELD_FEE);
         }
         yieldFeePercentage = _yieldFeePercentage;
         emit YieldFeePercentageSet(_yieldFeePercentage);

--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -490,9 +490,9 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
             return 0;
         } else {
             uint256 _availableYieldBalance = availableYieldBalance();
-            uint256 _maxWithdraw = yieldVault.maxWithdraw(address(this));
+            uint256 _maxWithdraw = yieldVault.maxWithdraw(address(this)) + _asset.balanceOf(address(this));
             uint256 _withdrawableYieldBalance = _availableYieldBalance >= _maxWithdraw ? _maxWithdraw : _availableYieldBalance;
-            return _withdrawableYieldBalance * (FEE_PRECISION - yieldFeePercentage) / FEE_PRECISION;
+            return _withdrawableYieldBalance.mulDiv(FEE_PRECISION - yieldFeePercentage, FEE_PRECISION);
         }
     }
 

--- a/test/contracts/mock/PrizePoolMock.sol
+++ b/test/contracts/mock/PrizePoolMock.sol
@@ -6,6 +6,9 @@ import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
 import { TwabController } from "pt-v5-twab-controller/TwabController.sol";
 
 contract PrizePoolMock {
+
+    event MockContribute(address prizeVault, uint256 amount);
+
     IERC20 public immutable prizeToken;
     TwabController public immutable twabController;
 
@@ -15,9 +18,11 @@ contract PrizePoolMock {
     }
 
     function contributePrizeTokens(
-        address,
-        /* _prizeVault */ uint256 /* _amount */
-    ) external view returns (uint256) {
-        return prizeToken.balanceOf(address(this));
+        address _prizeVault,
+        uint256 _amount
+    ) external returns (uint256) {
+        emit MockContribute(_prizeVault, _amount);
+        require(prizeToken.balanceOf(address(this)) >= _amount, "insufficient balance to contribute tokens");
+        return _amount;
     }
 }

--- a/test/unit/PrizeVault/Liquidate.t.sol
+++ b/test/unit/PrizeVault/Liquidate.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
+import { IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
+import { IERC20, UnitBaseSetup, PrizeVault } from "./UnitBaseSetup.t.sol";
+
+contract PrizeVaultLiquidationTest is UnitBaseSetup {
+
+    /* ============ liquidatableBalanceOf ============ */
+
+    function testLiquidatableBalanceOf_wrongToken() public {
+        ERC20Mock otherToken = new ERC20Mock();
+        assertNotEq(address(otherToken), address(vault.asset()));
+
+        otherToken.mint(address(vault), 1e18);
+        assertEq(vault.liquidatableBalanceOf(address(otherToken)), 0);
+    }
+
+    function testLiquidatableBalanceOf_noFee() public {
+        vault.setYieldFeePercentage(0); // no fee
+
+        underlyingAsset.mint(address(vault), 1e18);
+        assertEq(vault.liquidatableBalanceOf(address(underlyingAsset)), 1e18 - vault.yieldBuffer());
+    }
+
+    function testLiquidatableBalanceOf_withFee() public {
+        vault.setYieldFeePercentage(1e8); // 10%
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 availableYield = 1e18 - vault.yieldBuffer();
+        uint256 availableMinusFee = (availableYield * (1e9 - 1e8)) / 1e9;
+        assertEq(vault.liquidatableBalanceOf(address(underlyingAsset)), availableMinusFee);
+    }
+
+    /* ============ transferTokensOut ============ */
+
+    function testTransferTokensOut_noFee() public {
+        vault.setYieldFeePercentage(0); // no fee
+        vault.setYieldFeeRecipient(bob);
+        vault.setLiquidationPair(address(this));
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 amountOut = vault.liquidatableBalanceOf(address(underlyingAsset));
+        assertGt(amountOut, 0);
+
+        vm.expectEmit();
+        emit Transfer(address(vault), alice, amountOut);
+
+        vault.transferTokensOut(address(0), alice, address(underlyingAsset), amountOut);
+
+        assertEq(underlyingAsset.balanceOf(alice), amountOut);
+        assertEq(underlyingAsset.balanceOf(bob), 0);
+    }
+
+    // Fee is set, but recipient is the zero address, so no fee should be transferred
+    function testTransferTokensOut_noFeeSinceFeeRecipientZero() public {
+        vault.setYieldFeePercentage(1e8); // 10% fee
+        vault.setYieldFeeRecipient(address(0));
+        vault.setLiquidationPair(address(this));
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 amountOut = vault.liquidatableBalanceOf(address(underlyingAsset));
+        assertGt(amountOut, 0);
+
+        vm.expectEmit();
+        emit Transfer(address(vault), alice, amountOut);
+
+        vault.transferTokensOut(address(0), alice, address(underlyingAsset), amountOut);
+
+        assertEq(underlyingAsset.balanceOf(alice), amountOut);
+        assertEq(underlyingAsset.balanceOf(address(0)), 0);
+    }
+
+    function testTransferTokensOut_withFee() public {
+        vault.setYieldFeePercentage(1e8); // 10% fee
+        vault.setYieldFeeRecipient(bob);
+        vault.setLiquidationPair(address(this));
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 amountOut = vault.liquidatableBalanceOf(address(underlyingAsset));
+        uint256 yieldFee = 1e18 - vault.yieldBuffer() - amountOut;
+        assertGt(amountOut, 0);
+
+        vm.expectEmit();
+        emit Transfer(address(vault), alice, amountOut);
+
+        vm.expectEmit();
+        emit Transfer(address(vault), bob, yieldFee);
+
+        vault.transferTokensOut(address(0), alice, address(underlyingAsset), amountOut);
+
+        assertEq(underlyingAsset.balanceOf(alice), amountOut);
+        assertEq(underlyingAsset.balanceOf(bob), yieldFee);
+
+        assertEq(amountOut / yieldFee, (1e9 - 1e8) / 1e8); // ratio of (amountOut : yieldFee) equal to (1 - feePercentage : feePercentage) 
+    }
+
+    function testTransferTokensOut_CallerNotLP() public {
+        vm.startPrank(bob);
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.CallerNotLP.selector, bob, vault.liquidationPair()));
+        vault.transferTokensOut(address(0), bob, address(underlyingAsset), 0);
+        vm.stopPrank();
+    }
+
+    function testTransferTokensOut_LiquidationTokenOutNotAsset() public {
+        vm.startPrank(vault.liquidationPair());
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.LiquidationTokenOutNotAsset.selector, address(vault), address(underlyingAsset)));
+        vault.transferTokensOut(address(0), bob, address(vault), 0);
+        vm.stopPrank();
+    }
+
+    function testTransferTokensOut_LiquidationAmountOutZero() public {
+        vm.startPrank(vault.liquidationPair());
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.LiquidationAmountOutZero.selector));
+        vault.transferTokensOut(address(0), bob, address(underlyingAsset), 0);
+        vm.stopPrank();
+    }
+
+    function testTransferTokensOut_LiquidationExceedsAvailable() public {
+        vault.setYieldFeePercentage(0); // no fee
+        vault.setLiquidationPair(address(this));
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 amountOut = vault.liquidatableBalanceOf(address(underlyingAsset));
+        assertGt(amountOut, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.LiquidationExceedsAvailable.selector, amountOut + 1, amountOut));
+        vault.transferTokensOut(address(0), bob, address(underlyingAsset), amountOut + 1);
+    }
+
+    /* ============ verifyTokensIn ============ */
+
+    function testVerifyTokensIn() public {
+        prizeToken.mint(address(prizePool), 1e18);
+        vm.startPrank(vault.liquidationPair());
+
+        vm.expectEmit();
+        emit MockContribute(address(vault), 1e18);
+        vault.verifyTokensIn(address(prizeToken), 1e18, "");
+
+        vm.stopPrank();
+    }
+
+    function testVerifyTokensIn_CallerNotLP() public {
+        prizeToken.mint(address(prizePool), 1e18);
+        vm.startPrank(bob);
+
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.CallerNotLP.selector, bob, vault.liquidationPair()));
+        vault.verifyTokensIn(address(prizeToken), 1e18, "");
+
+        vm.stopPrank();
+    }
+
+    function testVerifyTokensIn_LiquidationTokenInNotPrizeToken() public {
+        prizeToken.mint(address(prizePool), 1e18);
+        vm.startPrank(vault.liquidationPair());
+
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.LiquidationTokenInNotPrizeToken.selector, address(underlyingAsset), address(prizeToken)));
+        vault.verifyTokensIn(address(underlyingAsset), 1e18, "");
+
+        vm.stopPrank();
+    }
+
+}

--- a/test/unit/PrizeVault/PrizeVault.t.sol
+++ b/test/unit/PrizeVault/PrizeVault.t.sol
@@ -215,11 +215,15 @@ contract PrizeVaultTest is UnitBaseSetup {
         assertEq(vault.yieldFeePercentage(), YIELD_FEE_PERCENTAGE);
     }
 
-    function testSetYieldFeePercentageGT1e9() public {
+    function testSetYieldFeePercentageExceedsMax() public {
+        uint32 max = vault.MAX_YIELD_FEE();
+
+        vault.setYieldFeePercentage(max); // ok
+
         vm.expectRevert(
-            abi.encodeWithSelector(PrizeVault.YieldFeePercentageGtPrecision.selector, 2e9, 1e9)
+            abi.encodeWithSelector(PrizeVault.YieldFeePercentageExceedsMax.selector, max + 1, max)
         );
-        vault.setYieldFeePercentage(2e9);
+        vault.setYieldFeePercentage(max + 1); // not ok
     }
 
     function testSetYieldFeePercentageOnlyOwner() public {

--- a/test/unit/PrizeVault/UnitBaseSetup.t.sol
+++ b/test/unit/PrizeVault/UnitBaseSetup.t.sol
@@ -27,6 +27,7 @@ contract UnitBaseSetup is Test {
     event LiquidationPairSet(address indexed tokenOut, address indexed liquidationPair);
     event YieldFeeRecipientSet(address indexed yieldFeeRecipient);
     event YieldFeePercentageSet(uint256 yieldFeePercentage);
+    event MockContribute(address prizeVault, uint256 amount);
 
     /* ============ variables ============ */
 


### PR DESCRIPTION
- Send fee directly to recipient on liquidation
- Decrease max fee percentage to a more reasonable value to protect deployers from setting it too high such that liquidations don't occur at all. (if liquidations don't occur, there will be no fees collected)
- Remove 100% yield fee logical exceptions
- Fix `_withdraw` function so it does not call an additional transfer if withdrawing to self