### PR TITLE
Require yield buffer donation on deployment through factory

### DIFF
--- a/src/PrizeVaultFactory.sol
+++ b/src/PrizeVaultFactory.sol
@@ -47,6 +47,8 @@ contract PrizeVaultFactory {
     /**
      * @notice Deploy a new vault
      * @dev `claimer` can be set to address zero if none is available yet.
+     * @dev The caller MUST approve this factory to spend underlying assets equal to `_yieldBuffer` so the yield
+     * buffer can be filled on deployment. This value is unrecoverable and is expected to be insignificant.
      * @param _name Name of the ERC20 share minted by the vault
      * @param _symbol Symbol of the ERC20 share minted by the vault
      * @param _yieldVault Address of the ERC4626 vault in which assets are deposited to generate yield
@@ -82,6 +84,12 @@ contract PrizeVaultFactory {
             _yieldBuffer,
             _owner
         );
+
+        // A donation to fill the yield buffer is made to ensure that early depositors have
+        // rounding errors covered in the time before yield is actually generated.
+        if (_yieldBuffer > 0) {
+            IERC20(_vault.asset()).transferFrom(msg.sender, address(_vault), _yieldBuffer);
+        }
 
         allVaults.push(_vault);
         deployedVaults[address(_vault)] = true;


### PR DESCRIPTION
## Motivation

The yield buffer should be filled before the first deposit to ensure that it is covered for any rounding errors. This should ideally be on construction of prize vault, but this can be difficult to execute since the address of the prize vault needs to be predicted beforehand to be able to approve the required assets. Since most prize vault deployments will be made through the factory, the donation can be enforced there instead and be made after the constructor has been called so that no address prediction is necessary.

Any other direct deployments of the prize vault will be expected to have their own strategy for covering the yield buffer.

## Mechanism

The vault factory transfers `yieldBuffer` assets from the deployer to the new vault immediately after construction. It does not need to deposit these into the yield vault since the latent assets in the prize vault are accounted for and will be automatically deposited on the next `deposit` or `mint` call. This saves gas on deployment since no yield vault deposit is necessary.