### PR TITLE
Mitigate permit frontrunning

### DIFF
--- a/test/unit/PrizeVault/DepositPermitFallback.t.sol
+++ b/test/unit/PrizeVault/DepositPermitFallback.t.sol
@@ -18,7 +18,25 @@ contract PrizeVaultDepositPermitFallbackTest is UnitBaseSetup {
 
     /* ============ tests ============ */
 
-    function testDepositWithoutPermit_AllowanceNotSet() external {
+    function testDepositWithoutPermit_SucceedsIfApprovalIsExact() external {
+        vm.startPrank(alice);
+
+        uint256 _amount = 1000e18;
+        underlyingAsset.mint(alice, _amount);
+
+        underlyingAsset.approve(address(vault), _amount); // exact approval
+
+        uint8 _v = 0;
+        bytes32 _r = bytes32(0);
+        bytes32 _s = bytes32(0);
+        vault.depositWithPermit(_amount, alice, block.timestamp, _v, _r, _s);
+
+        assertEq(vault.balanceOf(alice), _amount);
+
+        vm.stopPrank();
+    }
+
+    function testDepositWithoutPermit_PermitAllowanceNotSet() external {
         vm.startPrank(alice);
 
         uint256 _amount = 1000e18;

--- a/test/unit/PrizeVault/DepositPermitFallback.t.sol
+++ b/test/unit/PrizeVault/DepositPermitFallback.t.sol
@@ -36,32 +36,6 @@ contract PrizeVaultDepositPermitFallbackTest is UnitBaseSetup {
         vm.stopPrank();
     }
 
-    function testDepositWithoutPermit_PermitAllowanceNotSet() external {
-        vm.startPrank(alice);
-
-        uint256 _amount = 1000e18;
-        underlyingAsset.mint(alice, _amount);
-
-        underlyingAsset.approve(address(vault), _amount * 2);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                PrizeVault.PermitAllowanceNotSet.selector,
-                alice,
-                address(vault),
-                _amount,
-                _amount * 2
-            )
-        );
-
-        uint8 _v = 0;
-        bytes32 _r = bytes32(0);
-        bytes32 _s = bytes32(0);
-        vault.depositWithPermit(_amount, alice, block.timestamp, _v, _r, _s);
-
-        vm.stopPrank();
-    }
-
     function testForceDepositWithoutPermitByThirdParty() external {
         vm.startPrank(alice);
 


### PR DESCRIPTION
### Motivation

The bug report stated that a griefer could read the signature calldata from a `depositWithPermit` tx in the mempool and frontrun the tx by calling `permit` on the underlying asset with the same signature data, thus causing the original tx to fail since the nonce would be used up.

### Original Recommendation

The recommended fix checked to see if the ample allowance was set before calling the permit function. This would fix the issue since the permit would not be called if it were frontrun, since the allowance would have already been set. The fix:

```solidity
function depositWithPermit(
    ...
) external returns (uint256) {
    if (_owner != msg.sender) {
      revert PermitCallerNotOwner(msg.sender, _owner);
    }
  
    if (IERC20(_token).allowance(_owner, spender) < _assets) {
        IERC20Permit(address(_asset)).permit(_owner, address(this), _assets, _deadline, _v, _r, _s);
    }
  
    uint256 _shares = previewDeposit(_assets);
    _depositAndMint(_owner, _owner, _assets, _shares);
    return _shares;
}
```

However, this can lead to some unexpected outcomes. Let's assume Alice is trying to deposit 100 assets and already has an approval for 10,000 assets on the vault, however, Alice wants to deposit with permit since she wishes to deposit *and* remove her excess approval in one transaction. She expects that by calling `depositWithPermit`, the permit call will reset the vault's allowance down to exactly 100 assets, and then reduce it to zero after the deposit is complete. However, when the call is made, the vault skips the approval and completes the deposit. Additionally, since her permit signature was never used, a griefer could submit it on her behalf at a later time as long as the deadline has not expired and Alice hasn't made any additional permit calls.

### Revised Recommendation

We should ensure that the permit is called no matter the outcome to prevent the depositor's permit signature from being misused at a later time. However, we must also ensure that the transaction doesn't fail if the permit is frontrun by a griefer. The solution proposed surrounds the permit call with a try-catch as follows:

```solidity
function depositWithPermit(
      ...
  ) external returns (uint256) {
      if (_owner != msg.sender) {
          revert PermitCallerNotOwner(msg.sender, _owner);
      }

      try IERC20Permit(address(_asset)).permit(_owner, address(this), _assets, _deadline, _v, _r, _s) { } catch { }

      uint256 _allowance = _asset.allowance(_owner, address(this));
      if (_allowance != _assets) {
          revert PermitAllowanceNotSet(_owner, address(this), _assets, _allowance);
      }

      uint256 _shares = previewDeposit(_assets);
      _depositAndMint(_owner, _owner, _assets, _shares);
      return _shares;
  }
```

After the permit call, we still check that the allowance *exactly* matches the expected value. If not, it is likely that the permit did not work at all (neither in the call or in a frontrun scenario).

### Revised *revised*

Calls the permit only if the current allowance is not exactly equal to the asset value. This allows us to remove the try-catch and the conditional revert.