### PR TITLE
Respect yield vault redeem limits on prize vault maxWithdraw and maxRedeem

### DIFF
--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -380,7 +380,7 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     /// @inheritdoc IERC4626
     /// @dev TODO: add reasoning for inclusion of latent balance
     function maxWithdraw(address _owner) public view returns (uint256) {
-        uint256 _maxWithdraw = yieldVault.maxWithdraw(address(this)) + _asset.balanceOf(address(this));
+        uint256 _maxWithdraw = _maxYieldVaultWithdraw() + _asset.balanceOf(address(this));
 
         // the owner may receive less than 1 asset per share, so we must convert their balance here
         uint256 _ownerAssets = convertToAssets(balanceOf(_owner));
@@ -390,7 +390,7 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     /// @inheritdoc IERC4626
     /// @dev TODO: add reasoning for inclusion of latent balance
     function maxRedeem(address _owner) public view returns (uint256) {
-        uint256 _maxWithdraw = yieldVault.maxWithdraw(address(this)) + _asset.balanceOf(address(this));
+        uint256 _maxWithdraw = _maxYieldVaultWithdraw() + _asset.balanceOf(address(this));
         uint256 _ownerShares = balanceOf(_owner);
 
         // The owner will never receive more than 1 asset per share, so there is no need to convert max
@@ -649,7 +649,7 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
             _maxAmountOut = _twabSupplyLimit(_totalSupply);
         } else if (_tokenOut == address(_asset)) {
             // Liquidation of yield assets is capped at the max withdraw.
-            _maxAmountOut = yieldVault.maxWithdraw(address(this)) + _asset.balanceOf(address(this));
+            _maxAmountOut = _maxYieldVaultWithdraw() + _asset.balanceOf(address(this));
         } else {
             return 0;
         }
@@ -898,6 +898,21 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
         _withdraw(_receiver, _assets);
 
         emit Withdraw(_caller, _receiver, _owner, _assets, _shares);
+    }
+
+    /**
+     * @notice Returns the max assets that can be withdrawn from the yield vault through this vault's
+     * `_withdraw` function.
+     * @dev This should be used over `yieldVault.maxWithdraw` when considering withdrawal limits since
+     * this function takes into account the yield vault redemption limits, which is necessary since the
+     * `_withdraw` function uses `yieldVault.redeem` instead of `yieldVault.withdraw`. Since we convert
+     * the max redeemable shares to assets rounding down, the `yieldVault.previewWithdraw` call in the
+     * `_withdraw` function is guaranteed to return less than or equal shares to the max yield vault 
+     * redemption.
+     * @return The max assets that can be withdrawn from the yield vault.
+     */
+    function _maxYieldVaultWithdraw() internal view returns (uint256) {
+        return yieldVault.convertToAssets(yieldVault.maxRedeem(address(this)));
     }
 
     /**

--- a/test/contracts/mock/YieldVaultMaxSetter.sol
+++ b/test/contracts/mock/YieldVaultMaxSetter.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { YieldVault, Math } from "./YieldVault.sol";
+
+contract YieldVaultMaxSetter is YieldVault {
+    using Math for uint256;
+
+    uint256 internal _maxWithdraw;
+    uint256 internal _maxRedeem;
+
+    constructor(address _asset) YieldVault(_asset, "YieldVaultMaxSetter", "yvMaxSet") {}
+
+    function setMaxWithdraw(uint256 maxWithdraw_) public {
+        _maxWithdraw = maxWithdraw_;
+    }
+
+    function setMaxRedeem(uint256 maxRedeem_) public {
+        _maxRedeem = maxRedeem_;
+    }
+
+    function maxWithdraw(address owner) public view override virtual returns(uint256) {
+        uint256 max = super.maxWithdraw(owner);
+        return max > _maxWithdraw ? _maxWithdraw : max;
+    }
+
+    function maxRedeem(address owner) public view override virtual returns(uint256) {
+        uint256 max = super.maxRedeem(owner);
+        return max > _maxRedeem ? _maxRedeem : max;
+    }
+
+    function redeem(uint256 shares, address owner, address receiver) public override virtual returns(uint256) {
+        require(shares <= maxRedeem(owner), "maxRedeem exceeded");
+        return super.redeem(shares, owner, receiver); 
+    }
+
+    function withdraw(uint256 assets, address owner, address receiver) public override virtual returns(uint256) {
+        require(assets <= maxWithdraw(owner), "maxWithdraw exceeded");
+        return super.withdraw(assets, owner, receiver); 
+    }
+
+    /**
+     * We override the virtual shares and assets implementation since this approach captures
+     * a very small part of the yield being accrued, which offsets by 1 wei
+     * the withdrawable amount from the YieldVault and skews our unit tests equality comparisons.
+     * Read this comment in the OpenZeppelin documentation to understand why:
+     * https://github.com/openzeppelin/openzeppelin-contracts/blob/eedca5d873a559140d79cc7ec674d0e28b2b6ebd/contracts/token/ERC20/extensions/ERC4626.sol#L30
+     */
+    function _convertToShares(
+        uint256 assets,
+        Math.Rounding rounding
+    ) internal view virtual override returns (uint256) {
+        uint256 supply = totalSupply();
+        return (assets == 0 || supply == 0) ? assets : assets.mulDiv(supply, totalAssets(), rounding);
+    }
+
+    function _convertToAssets(
+        uint256 shares,
+        Math.Rounding rounding
+    ) internal view virtual override returns (uint256) {
+        uint256 supply = totalSupply();
+        return (shares == 0 || supply == 0) ? shares : shares.mulDiv(totalAssets(), supply, rounding);
+    }
+    
+}

--- a/test/unit/PrizeVault/WithdrawalLimits.t.sol
+++ b/test/unit/PrizeVault/WithdrawalLimits.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { IERC4626 } from "openzeppelin/token/ERC20/extensions/ERC4626.sol";
+import { IERC20, UnitBaseSetup, PrizeVault } from "./UnitBaseSetup.t.sol";
+import { YieldVaultMaxSetter } from "../../contracts/mock/YieldVaultMaxSetter.sol";
+
+contract PrizeVaultWithdrawalLimitsTest is UnitBaseSetup {
+
+    YieldVaultMaxSetter internal _yieldVaultMaxSetter;
+
+    /* ============ override yield vault setup ============ */
+
+    function setUpYieldVault() public virtual override returns (IERC4626) {
+        _yieldVaultMaxSetter = new YieldVaultMaxSetter(address(underlyingAsset));
+        return _yieldVaultMaxSetter;
+    }
+
+    /* ============ withdraw limit test ============ */
+    
+    // This is a regression test that demonstrates an issue when using maxWithdraw as the upper limit when redeeming
+    // the shares that would be burned by the withdraw instead of calling the withdraw.
+    //
+    // - yield vault has 100 assets and a 1 share : 10 asset exchange rate
+    // - max withdraw is 95 assets on the yield vault, max redeem is 9 shares (assets rounded down)
+    // - alice wants to withdraw 95 assets from the prize vault
+    // - prize vault attempts to redeem 10 shares so that the 5 share rounding error is not lost
+    // - redemption fails since it exceeds the max redeem limit on the yield vault
+    //
+    // To pass this test, the prize vault MUST take into account the upper limit on the redemption when calculating
+    // the maxWithdraw limit.
+
+    function testWithdrawLimitNotPassedByRedeem() public {
+        // offset the exchange rate by a factor of ten by depositing 9 assets in the yield vault after minting 1 share.
+        vm.startPrank(bob);
+        underlyingAsset.mint(bob, 10);
+        underlyingAsset.approve(address(yieldVault), 10);
+        yieldVault.deposit(1, bob);
+        underlyingAsset.mint(address(yieldVault), 9);
+        vm.stopPrank();
+
+        assertEq(yieldVault.totalAssets(), 10);
+        assertEq(yieldVault.totalSupply(), 1);
+
+        // alice deposits 100 assets and the prize vault receives 10 shares
+        vm.startPrank(alice);
+        underlyingAsset.mint(alice, 100);
+        underlyingAsset.approve(address(vault), 100);
+        vault.deposit(100, alice);
+        vm.stopPrank();
+
+        assertEq(vault.balanceOf(alice), 100);
+        assertEq(vault.totalAssets(), 100);
+        assertEq(yieldVault.balanceOf(address(vault)), 10);
+
+        // set max withdraw on yield vault to 95 assets and max redeem to 9 shares
+        _yieldVaultMaxSetter.setMaxWithdraw(95);
+        _yieldVaultMaxSetter.setMaxRedeem(9);
+
+        assertEq(yieldVault.maxWithdraw(address(vault)), 95);
+        assertEq(yieldVault.maxRedeem(address(vault)), 9);
+
+        uint256 maxWithdrawAlice = vault.maxWithdraw(alice);
+
+        assertEq(maxWithdrawAlice, 90);
+        assertEq(vault.maxRedeem(alice), 90); // prize vault shares are 1:1 with assets
+
+        // alice withdraws 90 assets
+        vm.startPrank(alice);
+        vault.withdraw(maxWithdrawAlice, alice, alice);
+        vm.stopPrank();
+
+        // set max withdraw on yield vault to 5 assets and max redeem to 0 shares after withdrawal
+        _yieldVaultMaxSetter.setMaxWithdraw(5);
+        _yieldVaultMaxSetter.setMaxRedeem(0);
+
+        assertEq(vault.totalAssets(), 10);
+        assertEq(vault.totalSupply(), 10);
+        assertEq(yieldVault.balanceOf(address(vault)), 1);
+        assertEq(vault.maxWithdraw(alice), 0); // no yv shares can be redeemed, so no pv assets can be withdrawn
+        assertEq(vault.maxRedeem(alice), 0); // no yv shares can be redeemed, so no pv shares can be redeemed
+    }
+
+}


### PR DESCRIPTION
### Motivation

Consider the following scenario:

- yield vault has 100 assets and a 1 share : 10 asset exchange rate
- max withdraw is 95 assets on the yield vault, max redeem is 9 shares (assets rounded down)
- alice wants to withdraw 95 assets from the prize vault
- prize vault attempts to redeem 10 shares so that the 5 share rounding error is not lost
 - redemption fails since it exceeds the max redeem limit on the yield vault

### Conclusion

The prize vault MUST take into account the upper limit on the redemption when calculating the `maxWithdraw` and `maxRedeem` limit since all prize vault withdrawal and redeem flows use the yield vault `redeem` call to capture extreme rounding errors.