### PR TITLE
subtract only the amount of shares claimed from the yield fee balance

### DIFF
--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -610,11 +610,9 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     /// @dev Will revert if the caller is not the yield fee recipient or if zero shares are withdrawn
     function claimYieldFeeShares(uint256 _shares) external onlyYieldFeeRecipient {
         if (_shares == 0) revert MintZeroShares();
+        if (_shares > yieldFeeBalance) revert SharesExceedsYieldFeeBalance(_shares, yieldFeeBalance);
 
-        uint256 _yieldFeeBalance = yieldFeeBalance;
-        if (_shares > _yieldFeeBalance) revert SharesExceedsYieldFeeBalance(_shares, _yieldFeeBalance);
-
-        yieldFeeBalance -= _yieldFeeBalance;
+        yieldFeeBalance -= _shares;
 
         _mint(msg.sender, _shares);
 

--- a/test/unit/PrizeVault/Liquidate.t.sol
+++ b/test/unit/PrizeVault/Liquidate.t.sol
@@ -371,6 +371,17 @@ contract PrizeVaultLiquidationTest is UnitBaseSetup {
         vm.stopPrank();
 
         assertEq(vault.balanceOf(bob), yieldFeeBalance / 3);
+
+        // test a claim of the rest of the fees:        
+        vm.startPrank(bob);
+        vm.expectEmit();
+        emit Transfer(address(0), bob, (2 * yieldFeeBalance) / 3);
+        vm.expectEmit();
+        emit ClaimYieldFeeShares(bob, (2 * yieldFeeBalance) / 3);
+        vault.claimYieldFeeShares((2 * yieldFeeBalance) / 3);
+        vm.stopPrank();
+
+        assertEq(vault.balanceOf(bob), yieldFeeBalance);
     }
 
 }


### PR DESCRIPTION
The yield fee balance was being completely wiped regardless of the amount of shares being claimed. Instead, it should only subtract the amount of shares claimed.