### PR TITLE
Account for yieldFeeBalance in twabSupplyLimit

### DIFF
--- a/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
+++ b/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
@@ -35,6 +35,12 @@ contract LossyPrizeVaultInvariant is Test {
         }
     }
 
+    function invariantYieldFeeBalanceAlwaysClaimable() external {
+        uint256 supplyLimit = type(uint96).max - lossyVaultHarness.vault().totalSupply();
+        uint256 yieldFeeBalance = lossyVaultHarness.vault().yieldFeeBalance();
+        assertLe(yieldFeeBalance, supplyLimit);
+    }
+
     function invariantAllAssetsAccountedFor() external {
         uint256 totalAssets = lossyVaultHarness.vault().totalAssets();
         uint256 totalDebt = lossyVaultHarness.vault().totalDebt();

--- a/test/invariant/PrizeVault/PrizeVaultInvariant.t.sol
+++ b/test/invariant/PrizeVault/PrizeVaultInvariant.t.sol
@@ -47,6 +47,12 @@ contract PrizeVaultInvariant is Test {
         assertLe(liquidBalance, availableYieldBalance);
     }
 
+    function invariantYieldFeeBalanceAlwaysClaimable() external useCurrentTime {
+        uint256 supplyLimit = type(uint96).max - vaultHarness.vault().totalSupply();
+        uint256 yieldFeeBalance = vaultHarness.vault().yieldFeeBalance();
+        assertLe(yieldFeeBalance, supplyLimit);
+    }
+
     function invariantAllAssetsAccountedFor() external useCurrentTime {
         PrizeVault vault = vaultHarness.vault();
         uint256 totalAssets = vault.totalAssets();

--- a/test/unit/PrizeVault/Liquidate.t.sol
+++ b/test/unit/PrizeVault/Liquidate.t.sol
@@ -299,7 +299,7 @@ contract PrizeVaultLiquidationTest is UnitBaseSetup {
         uint256 amountOut = supplyCapLeft; // 10 assets too much
         // (even though there is available yield, the supply cap will be exceeded by the yield fee)
 
-        vm.expectRevert(abi.encodeWithSelector(PrizeVault.SupplyLimitExceeded.selector, 11)); // yield fee is 11
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.MintLimitExceeded.selector, 11)); // yield fee is 11
         vault.transferTokensOut(address(0), address(this), address(vault), amountOut);
     }
 

--- a/test/unit/PrizeVault/Liquidate.t.sol
+++ b/test/unit/PrizeVault/Liquidate.t.sol
@@ -92,6 +92,37 @@ contract PrizeVaultLiquidationTest is UnitBaseSetup {
         assertEq(vault.liquidatableBalanceOf(address(vault)), supplyCapLeft); // less than available yield since shares are capped at uint96 max
     }
 
+    function testLiquidatableBalanceOf_respectsMaxShareMintWithFee() public {
+        vault.setYieldFeePercentage(1e8); // 10%
+        vault.setYieldFeeRecipient(address(this));
+        vault.setLiquidationPair(address(this));
+
+        uint256 supplyCapLeft = 100;
+
+        // make a large deposit to use most of the shares:
+        underlyingAsset.mint(address(alice), type(uint96).max);
+        vm.startPrank(alice);
+        underlyingAsset.approve(address(vault), type(uint96).max - supplyCapLeft);
+        vault.deposit(type(uint96).max - supplyCapLeft, alice);
+        vm.stopPrank();
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 availableYield = vault.availableYieldBalance();
+        assertApproxEqAbs(availableYield, 1e18 - vault.yieldBuffer(), 1);
+
+        assertLt(supplyCapLeft, availableYield);
+
+        uint256 amountOut = (supplyCapLeft * 9) / 10;
+        assertEq(vault.liquidatableBalanceOf(address(vault)), amountOut);
+        vault.transferTokensOut(address(0), address(this), address(vault), amountOut);
+
+        assertEq(vault.liquidatableBalanceOf(address(vault)), 0);
+        assertEq(vault.yieldFeeBalance(), supplyCapLeft - amountOut);
+
+        // ensure the yield fee can be minted
+        vault.claimYieldFeeShares(supplyCapLeft - amountOut);
+    }
+
     /* ============ transferTokensOut ============ */
 
     function testTransferTokensOut_noFee() public {
@@ -242,6 +273,34 @@ contract PrizeVaultLiquidationTest is UnitBaseSetup {
         assertGt(amountOut, 0);
         vm.expectRevert(abi.encodeWithSelector(PrizeVault.LiquidationExceedsAvailable.selector, amountOut + 1, amountOut));
         vault.transferTokensOut(address(0), bob, address(vault), amountOut + 1);
+    }
+
+    function testTransferTokensOut_YieldFeeExceedsSupplyCap() public {
+        vault.setYieldFeePercentage(1e8); // 10%
+        vault.setYieldFeeRecipient(bob);
+        vault.setLiquidationPair(address(this));
+
+        uint256 supplyCapLeft = 100;
+
+        // make a large deposit to use most of the shares:
+        underlyingAsset.mint(address(alice), type(uint96).max);
+        vm.startPrank(alice);
+        underlyingAsset.approve(address(vault), type(uint96).max - supplyCapLeft);
+        vault.deposit(type(uint96).max - supplyCapLeft, alice);
+        vm.stopPrank();
+
+        underlyingAsset.mint(address(vault), 1e18);
+        uint256 availableYield = vault.availableYieldBalance();
+        assertApproxEqAbs(availableYield, 1e18 - vault.yieldBuffer(), 1);
+
+        assertLt(supplyCapLeft, availableYield);
+        assertEq((supplyCapLeft * 9) / 10, vault.liquidatableBalanceOf(address(vault)));
+
+        uint256 amountOut = supplyCapLeft; // 10 assets too much
+        // (even though there is available yield, the supply cap will be exceeded by the yield fee)
+
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.SupplyLimitExceeded.selector, 11)); // yield fee is 11
+        vault.transferTokensOut(address(0), address(this), address(vault), amountOut);
     }
 
     /* ============ verifyTokensIn ============ */


### PR DESCRIPTION
The TWAB supply limit is expected to never be reached in a prize vault, but if a deployer makes a mistake or if the underlying asset has a highly fluctuating total supply, it's possible that it can be. In this case, the accrued yield fee balance must be protected so that the yield fee funds can't be locked in by depositors.

These changes ensure that the yield fee balance is always accounted for in the TWAB total supply limit and ensures that no new mints, deposits or liquidations can occur if they will exceed this limit.