### PR TITLE
Revert when asset does not have decimals

### DIFF
--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -259,6 +259,10 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     /// @param minAssets The min asset threshold requested
     error MinAssetsNotReached(uint256 assets, uint256 minAssets);
 
+    /// @notice Thrown when the underlying asset does not specify it's number of decimals.
+    /// @param asset The underlying asset that was checked
+    error FailedToGetAssetDecimals(address asset);
+
     ////////////////////////////////////////////////////////////////////////////////
     // Modifiers
     ////////////////////////////////////////////////////////////////////////////////
@@ -309,7 +313,11 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
 
         IERC20 asset_ = IERC20(yieldVault_.asset());
         (bool success, uint8 assetDecimals) = _tryGetAssetDecimals(asset_);
-        _underlyingDecimals = success ? assetDecimals : 18;
+        if (success) {
+            _underlyingDecimals = assetDecimals;
+        } else {
+            revert FailedToGetAssetDecimals(address(asset_));
+        }
         _asset = asset_;
 
         yieldVault = yieldVault_;

--- a/test/unit/PrizeVault/PrizeVault.t.sol
+++ b/test/unit/PrizeVault/PrizeVault.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { UnitBaseSetup, PrizePool, TwabController, ERC20, IERC20, IERC4626 } from "./UnitBaseSetup.t.sol";
+import { UnitBaseSetup, PrizePool, TwabController, ERC20, IERC20, IERC4626, YieldVault } from "./UnitBaseSetup.t.sol";
 import { IVaultHooks, VaultHooks } from "../../../src/interfaces/IVaultHooks.sol";
 import { ERC20BrokenDecimalMock } from "../../contracts/mock/ERC20BrokenDecimalMock.sol";
 
@@ -178,6 +178,27 @@ contract PrizeVaultTest is UnitBaseSetup {
         (bool success, uint8 decimals) = vault.tryGetAssetDecimals(brokenDecimalToken);
         assertEq(success, false);
         assertEq(decimals, 0);
+    }
+
+    function testConstructorFailsWhenDecimalFails() public {
+        IERC20 brokenDecimalToken = new ERC20BrokenDecimalMock();
+        YieldVault brokenDecimalYieldVault = new YieldVault(
+            address(brokenDecimalToken),
+            "Test Yield Vault",
+            "yvTest"
+        );
+        vm.expectRevert(abi.encodeWithSelector(PrizeVault.FailedToGetAssetDecimals.selector, address(brokenDecimalToken)));
+        new PrizeVault(
+            "PoolTogether Decimal Fail",
+            "pDecFail",
+            brokenDecimalYieldVault,
+            PrizePool(address(prizePool)),
+            address(this),
+            address(this),
+            YIELD_FEE_PERCENTAGE,
+            1e6,
+            address(this)
+        );
     }
 
     /* ============ maxDeposit / maxMint ============ */


### PR DESCRIPTION
This is to ensure a consistent UX. Assets without `decimals()` are very rare, and there are varying standards for what the default decimals should be (some apps fallback to 0, some fallback to 18), so if someone wants to deploy a new PrizeVault with an asset that has no specified decimals, they should create a custom deployment that uses the most applicable decimal value for the asset.