### PR TITLE
Use preview functions for precise accounting

### DIFF
--- a/src/PrizeVault.sol
+++ b/src/PrizeVault.sol
@@ -840,14 +840,14 @@ contract PrizeVault is TwabERC20, Claimable, IERC4626, ILiquidationSource, Ownab
     }
 
     /// @notice Calculates the amount of assets the vault controls based on current onchain conditions.
-    /// @dev Follows the same calculation as `totalPreciseAssets`, but catches `previewRedeem` failures
-    /// and returns whether or not the call was successful.
+    /// @dev Calls `totalPreciseAssets` externally so it can catch `previewRedeem` failures and return
+    /// whether or not the call was successful.
     /// @return _success Returns true if totalAssets was successfully calculated and false otherwise
     /// @return _totalAssets The total assets controlled by the vault based on current onchain conditions
     function _tryGetTotalPreciseAssets() internal view returns (bool _success, uint256 _totalAssets) {
-        try yieldVault.previewRedeem(yieldVault.balanceOf(address(this))) returns (uint256 _yieldVaultAssets) {
+        try this.totalPreciseAssets() returns (uint256 _totalPreciseAssets) {
             _success = true;
-            _totalAssets = _yieldVaultAssets + _asset.balanceOf(address(this));
+            _totalAssets = _totalPreciseAssets;
         } catch {
             _success = false;
             _totalAssets = 0;

--- a/test/contracts/wrapper/PrizeVaultWrapper.sol
+++ b/test/contracts/wrapper/PrizeVaultWrapper.sol
@@ -21,6 +21,10 @@ contract PrizeVaultWrapper is PrizeVault {
         return _tryGetAssetDecimals(asset_);
     }
 
+    function tryGetTotalPreciseAssets() public view returns (bool, uint256) {
+        return _tryGetTotalPreciseAssets();
+    }
+
     function depositAndMint(address _caller, address _receiver, uint256 _assets, uint256 _shares) public {
         _depositAndMint(_caller, _receiver, _assets, _shares);
     }

--- a/test/fuzz/PrizeVault/ERC4626AndLiquidation.t.sol
+++ b/test/fuzz/PrizeVault/ERC4626AndLiquidation.t.sol
@@ -159,7 +159,7 @@ contract PrizeVaultERC4626AndLiquidationFuzzTest is ERC4626Test {
             abi.encodeWithSelector(PrizeVault.liquidatableBalanceOf.selector, _underlying_)
         );
 
-        uint256 totalAssets = prizeVault.totalAssets();
+        uint256 totalAssets = prizeVault.totalPreciseAssets();
         uint256 totalDebt = prizeVault.totalDebt();
 
         if (totalAssets < totalDebt + yieldBuffer) {

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -164,9 +164,9 @@ abstract contract BaseIntegration is Test, Permit {
 
     /// @dev Each integration test must override the `_accrueYield` internal function for this to work.
     function accrueYield() public returns (uint256) {
-        uint256 assetsBefore = prizeVault.totalAssets();
+        uint256 assetsBefore = prizeVault.totalPreciseAssets();
         _accrueYield();
-        uint256 assetsAfter = prizeVault.totalAssets();
+        uint256 assetsAfter = prizeVault.totalPreciseAssets();
         if (yieldVault.balanceOf(address(prizeVault)) > 0) {
             // if the prize vault has any yield vault shares, check to ensure yield has accrued
             require(assetsAfter > assetsBefore, "yield did not accrue");
@@ -185,9 +185,9 @@ abstract contract BaseIntegration is Test, Permit {
     /// @dev Each integration test must override the `_simulateLoss` internal function for this to work.
     /// @return The loss the prize vault has incurred as a result of yield vault loss (if any)
     function simulateLoss() public returns (uint256) {
-        uint256 assetsBefore = prizeVault.totalAssets();
+        uint256 assetsBefore = prizeVault.totalPreciseAssets();
         _simulateLoss();
-        uint256 assetsAfter = prizeVault.totalAssets();
+        uint256 assetsAfter = prizeVault.totalPreciseAssets();
         if (yieldVault.balanceOf(address(prizeVault)) > 0) {
             // if the prize vault has any yield vault shares, check to ensure some loss has occurred
             require(assetsAfter < assetsBefore, "loss not simulated");
@@ -248,7 +248,7 @@ abstract contract BaseIntegration is Test, Permit {
         uint256 amount = 10 ** assetDecimals;
         dealAssets(alice, amount);
 
-        uint256 totalAssetsBefore = prizeVault.totalAssets();
+        uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
         uint256 totalSupplyBefore = prizeVault.totalSupply();
 
         startPrank(alice);
@@ -256,7 +256,7 @@ abstract contract BaseIntegration is Test, Permit {
         prizeVault.deposit(amount, alice);
         stopPrank();
 
-        uint256 totalAssetsAfter = prizeVault.totalAssets();
+        uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
         uint256 totalSupplyAfter = prizeVault.totalSupply();
 
         assertEq(prizeVault.balanceOf(alice), amount, "shares minted");
@@ -275,7 +275,7 @@ abstract contract BaseIntegration is Test, Permit {
             uint256 amount = (10 ** assetDecimals) * (i + 1);
             dealAssets(depositors[i], amount);
 
-            uint256 totalAssetsBefore = prizeVault.totalAssets();
+            uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
             uint256 totalSupplyBefore = prizeVault.totalSupply();
 
             startPrank(depositors[i]);
@@ -283,7 +283,7 @@ abstract contract BaseIntegration is Test, Permit {
             prizeVault.deposit(amount, depositors[i]);
             stopPrank();
 
-            uint256 totalAssetsAfter = prizeVault.totalAssets();
+            uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
             uint256 totalSupplyAfter = prizeVault.totalSupply();
 
             assertEq(prizeVault.balanceOf(depositors[i]), amount, "shares minted");
@@ -302,7 +302,7 @@ abstract contract BaseIntegration is Test, Permit {
             uint256 amount = (10 ** assetDecimals) * (i + 1);
             dealAssets(depositors[i], amount);
 
-            uint256 totalAssetsBefore = prizeVault.totalAssets();
+            uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
             uint256 totalSupplyBefore = prizeVault.totalSupply();
 
             startPrank(depositors[i]);
@@ -310,7 +310,7 @@ abstract contract BaseIntegration is Test, Permit {
             prizeVault.deposit(amount, depositors[i]);
             stopPrank();
 
-            uint256 totalAssetsAfter = prizeVault.totalAssets();
+            uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
             uint256 totalSupplyAfter = prizeVault.totalSupply();
 
             assertEq(prizeVault.balanceOf(depositors[i]), amount, "shares minted");
@@ -334,7 +334,7 @@ abstract contract BaseIntegration is Test, Permit {
         uint256 amount = 10 ** assetDecimals;
         dealAssets(alice, amount);
 
-        uint256 totalAssetsBefore = prizeVault.totalAssets();
+        uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
         uint256 totalSupplyBefore = prizeVault.totalSupply();
 
         startPrank(alice);
@@ -343,7 +343,7 @@ abstract contract BaseIntegration is Test, Permit {
         prizeVault.withdraw(amount, alice, alice);
         stopPrank();
 
-        uint256 totalAssetsAfter = prizeVault.totalAssets();
+        uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
         uint256 totalSupplyAfter = prizeVault.totalSupply();
 
         assertEq(prizeVault.balanceOf(alice), 0, "burns all user shares on full withdraw");
@@ -357,7 +357,7 @@ abstract contract BaseIntegration is Test, Permit {
         uint256 amount = 10 ** assetDecimals;
         dealAssets(alice, amount);
 
-        uint256 totalAssetsBefore = prizeVault.totalAssets();
+        uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
         uint256 totalSupplyBefore = prizeVault.totalSupply();
 
         startPrank(alice);
@@ -367,7 +367,7 @@ abstract contract BaseIntegration is Test, Permit {
         prizeVault.withdraw(amount, alice, alice);
         stopPrank();
 
-        uint256 totalAssetsAfter = prizeVault.totalAssets();
+        uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
         uint256 totalSupplyAfter = prizeVault.totalSupply();
 
         assertEq(prizeVault.balanceOf(alice), 0, "burns all user shares on full withdraw");
@@ -397,14 +397,14 @@ abstract contract BaseIntegration is Test, Permit {
         // withdraw
         for (uint256 i = 0; i < depositors.length; i++) {
             uint256 amount = (10 ** assetDecimals) * (i + 1);
-            uint256 totalAssetsBefore = prizeVault.totalAssets();
+            uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
             uint256 totalSupplyBefore = prizeVault.totalSupply();
 
             startPrank(depositors[i]);
             prizeVault.withdraw(amount, depositors[i], depositors[i]);
             stopPrank();
 
-            uint256 totalAssetsAfter = prizeVault.totalAssets();
+            uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
             uint256 totalSupplyAfter = prizeVault.totalSupply();
 
             assertEq(prizeVault.balanceOf(depositors[i]), 0, "burned all user's shares on withdraw");
@@ -436,12 +436,12 @@ abstract contract BaseIntegration is Test, Permit {
         simulateLoss();
 
         // ensure prize vault is in lossy state
-        assertLt(prizeVault.totalAssets(), prizeVault.totalDebt());
+        assertLt(prizeVault.totalPreciseAssets(), prizeVault.totalDebt());
 
         // verify all users can withdraw a proportional amount of assets
         for (uint256 i = 0; i < depositors.length; i++) {
             uint256 shares = prizeVault.balanceOf(depositors[i]);
-            uint256 totalAssetsBefore = prizeVault.totalAssets();
+            uint256 totalAssetsBefore = prizeVault.totalPreciseAssets();
             uint256 totalSupplyBefore = prizeVault.totalSupply();
             uint256 totalDebtBefore = prizeVault.totalDebt();
             uint256 expectedAssets = (shares * totalAssetsBefore) / totalDebtBefore;
@@ -450,7 +450,7 @@ abstract contract BaseIntegration is Test, Permit {
             uint256 assets = prizeVault.redeem(shares, depositors[i], depositors[i]);
             stopPrank();
 
-            uint256 totalAssetsAfter = prizeVault.totalAssets();
+            uint256 totalAssetsAfter = prizeVault.totalPreciseAssets();
             uint256 totalSupplyAfter = prizeVault.totalSupply();
 
             assertEq(assets, expectedAssets, "assets received proportional to shares / totalDebt");

--- a/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
+++ b/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
@@ -15,10 +15,10 @@ contract LossyPrizeVaultInvariant is Test {
     }
 
     function invariantDisableDepositsOnLoss() external {
-        uint256 totalAssets = lossyVaultHarness.vault().totalAssets();
+        uint256 totalPreciseAssets = lossyVaultHarness.vault().totalPreciseAssets();
         uint256 totalDebt = lossyVaultHarness.vault().totalDebt();
         uint256 totalSupply = lossyVaultHarness.vault().totalSupply();
-        if (totalDebt > totalAssets || type(uint96).max - totalSupply == 0) {
+        if (totalDebt > totalPreciseAssets || type(uint96).max - totalSupply == 0) {
             assertEq(lossyVaultHarness.vault().maxDeposit(address(this)), 0);
         } else {
             assertGt(lossyVaultHarness.vault().maxDeposit(address(this)), 0);
@@ -26,9 +26,9 @@ contract LossyPrizeVaultInvariant is Test {
     }
 
     function invariantNoYieldWhenDebtExceedsAssets() external {
-        uint256 totalAssets = lossyVaultHarness.vault().totalAssets();
+        uint256 totalPreciseAssets = lossyVaultHarness.vault().totalPreciseAssets();
         uint256 totalDebt = lossyVaultHarness.vault().totalDebt();
-        if (totalDebt >= totalAssets) {
+        if (totalDebt >= totalPreciseAssets) {
             assertEq(lossyVaultHarness.vault().liquidatableBalanceOf(address(lossyVaultHarness.underlyingAsset())), 0);
             assertEq(lossyVaultHarness.vault().liquidatableBalanceOf(address(lossyVaultHarness.vault())), 0);
             assertEq(lossyVaultHarness.vault().availableYieldBalance(), 0);
@@ -42,22 +42,22 @@ contract LossyPrizeVaultInvariant is Test {
     }
 
     function invariantAllAssetsAccountedFor() external {
-        uint256 totalAssets = lossyVaultHarness.vault().totalAssets();
+        uint256 totalPreciseAssets = lossyVaultHarness.vault().totalPreciseAssets();
         uint256 totalDebt = lossyVaultHarness.vault().totalDebt();
-        if (totalDebt >= totalAssets) {
+        if (totalDebt >= totalPreciseAssets) {
             // 1 wei rounding error since the convertToAssets function rounds down which means up to 1 asset may be lost on total conversion
-            assertApproxEqAbs(totalAssets, lossyVaultHarness.vault().convertToAssets(totalDebt), 1);
+            assertApproxEqAbs(totalPreciseAssets, lossyVaultHarness.vault().convertToAssets(totalDebt), 1);
         } else {
             // When assets cover debts, we have essentially the same test as the the sister test in `PrizeVaultInvariant.sol`
             // The debt is converted to assets using `convertToAssets` to test that it will always be 1:1 when the vault has ample collateral.
             uint256 currentYieldBuffer = lossyVaultHarness.vault().currentYieldBuffer();
             uint256 availableYieldBalance = lossyVaultHarness.vault().availableYieldBalance();
             uint256 totalAccounted = lossyVaultHarness.vault().convertToAssets(totalDebt) + currentYieldBuffer + availableYieldBalance;
-            assertEq(totalAssets, totalAccounted);
+            assertEq(totalPreciseAssets, totalAccounted);
 
             // totalYieldBalance = currentYieldBuffer + availableYieldBalance
             uint256 totalAccounted2 = totalDebt + lossyVaultHarness.vault().totalYieldBalance();
-            assertEq(totalAssets, totalAccounted2);
+            assertEq(totalPreciseAssets, totalAccounted2);
         }
     }
 }

--- a/test/invariant/PrizeVault/PrizeVaultInvariant.t.sol
+++ b/test/invariant/PrizeVault/PrizeVaultInvariant.t.sol
@@ -22,7 +22,7 @@ contract PrizeVaultInvariant is Test {
     }
 
     function invariantAssetsCoverDebt() external useCurrentTime {
-        uint256 totalAssets = vaultHarness.vault().totalAssets();
+        uint256 totalAssets = vaultHarness.vault().totalPreciseAssets();
         uint256 totalDebt = vaultHarness.vault().totalDebt();
         assertGe(totalAssets, totalDebt);
     }
@@ -55,7 +55,7 @@ contract PrizeVaultInvariant is Test {
 
     function invariantAllAssetsAccountedFor() external useCurrentTime {
         PrizeVault vault = vaultHarness.vault();
-        uint256 totalAssets = vault.totalAssets();
+        uint256 totalAssets = vault.totalPreciseAssets();
         uint256 totalDebt = vault.totalDebt();
         uint256 currentYieldBuffer = vault.currentYieldBuffer();
         uint256 availableYieldBalance = vault.availableYieldBalance();

--- a/test/unit/PrizeVault/AaveV3WhilePaused.t.sol
+++ b/test/unit/PrizeVault/AaveV3WhilePaused.t.sol
@@ -250,9 +250,9 @@ contract AaveV3WhilePaused is UnitBaseSetup {
     // liquidating shares doesn't require the assets to be withdrawn from aave, so this will still work when paused.
     function testLiquidateSharesSucceeds() external {
         // accrue yield by letting time pass
-        uint256 totalAssetsBefore = vault.totalAssets();
+        uint256 totalAssetsBefore = vault.totalPreciseAssets();
         vm.warp(block.timestamp + 60 * 60 * 24);
-        uint256 totalAssetsAfter = vault.totalAssets();
+        uint256 totalAssetsAfter = vault.totalPreciseAssets();
         assertGt(totalAssetsAfter, totalAssetsBefore);
 
         // check share liquidation
@@ -270,9 +270,9 @@ contract AaveV3WhilePaused is UnitBaseSetup {
     // liquidating assets requires that the assets are able to be withdrawn, which is not the case when paused.
     function testLiquidatableAssetsZero() external {
         // accrue yield by letting time pass
-        uint256 totalAssetsBefore = vault.totalAssets();
+        uint256 totalAssetsBefore = vault.totalPreciseAssets();
         vm.warp(block.timestamp + 60 * 60 * 24);
-        uint256 totalAssetsAfter = vault.totalAssets();
+        uint256 totalAssetsAfter = vault.totalPreciseAssets();
         assertGt(totalAssetsAfter, totalAssetsBefore);
 
         // check asset liquidation

--- a/test/unit/PrizeVault/WithdrawalLimits.t.sol
+++ b/test/unit/PrizeVault/WithdrawalLimits.t.sol
@@ -50,7 +50,7 @@ contract PrizeVaultWithdrawalLimitsTest is UnitBaseSetup {
         vm.stopPrank();
 
         assertEq(vault.balanceOf(alice), 100);
-        assertEq(vault.totalAssets(), 100);
+        assertEq(vault.totalPreciseAssets(), 100);
         assertEq(yieldVault.balanceOf(address(vault)), 10);
 
         // set max withdraw on yield vault to 95 assets and max redeem to 9 shares
@@ -74,7 +74,7 @@ contract PrizeVaultWithdrawalLimitsTest is UnitBaseSetup {
         _yieldVaultMaxSetter.setMaxWithdraw(5);
         _yieldVaultMaxSetter.setMaxRedeem(0);
 
-        assertEq(vault.totalAssets(), 10);
+        assertEq(vault.totalPreciseAssets(), 10);
         assertEq(vault.totalSupply(), 10);
         assertEq(yieldVault.balanceOf(address(vault)), 1);
         assertEq(vault.maxWithdraw(alice), 0); // no yv shares can be redeemed, so no pv assets can be withdrawn

--- a/test/unit/PrizeVault/WithdrawalSlippage.t.sol
+++ b/test/unit/PrizeVault/WithdrawalSlippage.t.sol
@@ -18,14 +18,14 @@ contract PrizeVaultWithdrawalSlippageTest is UnitBaseSetup {
         vm.stopPrank();
 
         assertEq(vault.balanceOf(alice), 100);
-        assertEq(vault.totalAssets(), 100);
+        assertEq(vault.totalPreciseAssets(), 100);
 
         // yield vault loses 50% of assets
         vm.startPrank(address(yieldVault));
         underlyingAsset.burn(address(yieldVault), 50);
         vm.stopPrank();
 
-        assertEq(vault.totalAssets(), 50);
+        assertEq(vault.totalPreciseAssets(), 50);
 
         // alice should be able to withdraw up to 50 assets for 100 shares
         assertEq(vault.maxWithdraw(alice), 50);
@@ -65,14 +65,14 @@ contract PrizeVaultWithdrawalSlippageTest is UnitBaseSetup {
         vm.stopPrank();
 
         assertEq(vault.balanceOf(alice), 100);
-        assertEq(vault.totalAssets(), 100);
+        assertEq(vault.totalPreciseAssets(), 100);
 
         // yield vault loses 50% of assets
         vm.startPrank(address(yieldVault));
         underlyingAsset.burn(address(yieldVault), 50);
         vm.stopPrank();
 
-        assertEq(vault.totalAssets(), 50);
+        assertEq(vault.totalPreciseAssets(), 50);
 
         // alice should be able to redeem up to 100 shares for 50 assets
         assertEq(vault.maxWithdraw(alice), 50);


### PR DESCRIPTION
### Summary

`convertToAssets` and `convertToShares` are not guaranteed to use current onchain conditions to calculate conversions and may use some approximation to return more of an "average" prize. Yield vaults that implement these as average price oracles may behave poorly with the prize vault when these functions are used for precise accounting functions.

To address this, usage of these functions have been replaced with the yield vault `preview` functions instead to provide precise accounting based on current onchain conditions. However, this comes with new challenges since these preview functions may revert in some scenarios, but must be used in the prize vault's `maxDeposit`, `maxWithdraw`, etc. functions, which *MUST* not revert. The following changes have been made to allow the usage of these preview functions:

- New function added: `totalPreciseAssets()` *(returns the total assets using current rates from the yield vault `previewRedeem` function)*
- New function added: `_tryGetTotalPreciseAssets()` *(Attempts to fetch the `totalPreciseAssets`, but catches any reversions and indicates that the call was unsuccessful. This function is used in the `maxDeposit`, `maxWithdraw`, etc. functions so they can return zero instead of reverting)*
- `totalAssets()` is no longer used for any accounting functions besides `convertToAssets` and `convertToShares`, since all three of these functions are treated as "approximations" by the spec.