### PR TITLE
Refactor Prize Hooks

### DIFF
--- a/src/abstract/HookManager.sol
+++ b/src/abstract/HookManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { VaultHooks } from "../interfaces/IVaultHooks.sol";
+import { PrizeHooks } from "../interfaces/IPrizeHooks.sol";
 
 /// @title  PoolTogether V5 HookManager
 /// @author G9 Software Inc.
@@ -11,22 +11,22 @@ abstract contract HookManager {
     /// @notice Emitted when an account sets new hooks
     /// @param account The account whose hooks are being configured
     /// @param hooks The hooks being set
-    event SetHooks(address indexed account, VaultHooks hooks);
+    event SetHooks(address indexed account, PrizeHooks hooks);
 
     /// @notice Maps user addresses to hooks that they want to execute when prizes are won.
-    mapping(address => VaultHooks) internal _hooks;
+    mapping(address => PrizeHooks) internal _hooks;
 
     /// @notice Gets the hooks for the given account.
     /// @param account The account to retrieve the hooks for
-    /// @return VaultHooks The hooks for the given account
-    function getHooks(address account) external view returns (VaultHooks memory) {
+    /// @return PrizeHooks The hooks for the given account
+    function getHooks(address account) external view returns (PrizeHooks memory) {
         return _hooks[account];
     }
 
     /// @notice Sets the hooks for a winner.
     /// @dev Emits a `SetHooks` event
     /// @param hooks The hooks to set
-    function setHooks(VaultHooks calldata hooks) external {
+    function setHooks(PrizeHooks calldata hooks) external {
         _hooks[msg.sender] = hooks;
         emit SetHooks(msg.sender, hooks);
     }

--- a/src/interfaces/IPrizeHooks.sol
+++ b/src/interfaces/IPrizeHooks.sol
@@ -5,16 +5,16 @@ pragma solidity ^0.8.24;
 /// @param useBeforeClaimPrize If true, the vault will call the beforeClaimPrize hook on the implementation
 /// @param useAfterClaimPrize If true, the vault will call the afterClaimPrize hook on the implementation
 /// @param implementation The address of the smart contract implementing the hooks
-struct VaultHooks {
+struct PrizeHooks {
     bool useBeforeClaimPrize;
     bool useAfterClaimPrize;
-    IVaultHooks implementation;
+    IPrizeHooks implementation;
 }
 
-/// @title  PoolTogether V5 Vault Hooks Interface
+/// @title  PoolTogether V5 Prize Hooks Interface
 /// @author PoolTogether Inc. & G9 Software Inc.
 /// @notice Allows winners to attach smart contract hooks to their prize winnings
-interface IVaultHooks {
+interface IPrizeHooks {
     
     /// @notice Triggered before the prize pool claim prize function is called.
     /// @param winner The user who won the prize and for whom this hook is attached
@@ -22,26 +22,29 @@ interface IVaultHooks {
     /// @param prizeIndex The index of the prize in the tier
     /// @param reward The reward portion of the prize that will be allocated to the claimer
     /// @param rewardRecipient The recipient of the claim reward
-    /// @return address The address of the recipient of the prize
+    /// @return prizeRecipient The address of the recipient of the prize
+    /// @return data Arbitrary data that will be passed to the `afterClaimPrize` hook
     function beforeClaimPrize(
         address winner,
         uint8 tier,
         uint32 prizeIndex,
         uint96 reward,
         address rewardRecipient
-    ) external returns (address);
+    ) external returns (address prizeRecipient, bytes memory data);
 
     /// @notice Triggered after the prize pool claim prize function is called.
     /// @param winner The user who won the prize and for whom this hook is attached
     /// @param tier The tier of the prize
     /// @param prizeIndex The index of the prize
-    /// @param prize The total size of the prize (payout + reward)
-    /// @param recipient The recipient of the prize
+    /// @param prize The total size of the prize (not including the claim reward)
+    /// @param prizeRecipient The recipient of the prize
+    /// @param data Arbitrary data received from the `beforeClaimPrize` hook
     function afterClaimPrize(
         address winner,
         uint8 tier,
         uint32 prizeIndex,
         uint256 prize,
-        address recipient
+        address prizeRecipient,
+        bytes memory data
     ) external;
 }

--- a/test/contracts/wrapper/HookManagerWrapper.sol
+++ b/test/contracts/wrapper/HookManagerWrapper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { HookManager, VaultHooks } from "../../../src/abstract/HookManager.sol";
+import { HookManager, PrizeHooks } from "../../../src/abstract/HookManager.sol";
 
 contract HookManagerWrapper is HookManager { }

--- a/test/unit/HookManager.t.sol
+++ b/test/unit/HookManager.t.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 
-import { HookManagerWrapper, HookManager, VaultHooks } from "../contracts/wrapper/HookManagerWrapper.sol";
-import { IVaultHooks } from "../../src/interfaces/IVaultHooks.sol";
+import { HookManagerWrapper, HookManager, PrizeHooks } from "../contracts/wrapper/HookManagerWrapper.sol";
+import { IPrizeHooks } from "../../src/interfaces/IPrizeHooks.sol";
 
 contract HookManagerTest is Test {
 
     // Events:
-    event SetHooks(address indexed account, VaultHooks hooks);
+    event SetHooks(address indexed account, PrizeHooks hooks);
 
     HookManagerWrapper hookManager;
 
@@ -26,8 +26,8 @@ contract HookManagerTest is Test {
     /* ============ setHooks ============ */
 
     function testSetHooks() public {
-        VaultHooks memory beforeHooks = hookManager.getHooks(alice);
-        VaultHooks memory newHooks = VaultHooks(true, true, IVaultHooks(address(this)));
+        PrizeHooks memory beforeHooks = hookManager.getHooks(alice);
+        PrizeHooks memory newHooks = PrizeHooks(true, true, IPrizeHooks(address(this)));
         assertNotEq(hashHooks(beforeHooks), hashHooks(newHooks));
 
         vm.startPrank(alice);
@@ -38,7 +38,7 @@ contract HookManagerTest is Test {
         
         vm.stopPrank();
 
-        VaultHooks memory actualHooks = hookManager.getHooks(alice);
+        PrizeHooks memory actualHooks = hookManager.getHooks(alice);
 
         assertEq(hashHooks(newHooks), hashHooks(actualHooks));
     }
@@ -46,14 +46,14 @@ contract HookManagerTest is Test {
     /* ============ getHooks ============ */
 
     function testGetHooks_Empty() public {
-        VaultHooks memory hooks = hookManager.getHooks(alice);
-        VaultHooks memory emptyHooks = VaultHooks(false, false, IVaultHooks(address(0)));
+        PrizeHooks memory hooks = hookManager.getHooks(alice);
+        PrizeHooks memory emptyHooks = PrizeHooks(false, false, IPrizeHooks(address(0)));
         assertEq(hashHooks(hooks), hashHooks(emptyHooks));
     }
 
     /* ============ helpers ============ */
 
-    function hashHooks(VaultHooks memory hooks) public pure returns (bytes32) {
+    function hashHooks(PrizeHooks memory hooks) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(
             hooks.useBeforeClaimPrize,
             hooks.useAfterClaimPrize,

--- a/test/unit/PrizeVault/PrizeVault.t.sol
+++ b/test/unit/PrizeVault/PrizeVault.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { UnitBaseSetup, PrizePool, TwabController, ERC20, IERC20, IERC4626, YieldVault } from "./UnitBaseSetup.t.sol";
-import { IVaultHooks, VaultHooks } from "../../../src/interfaces/IVaultHooks.sol";
+import { IPrizeHooks, PrizeHooks } from "../../../src/interfaces/IPrizeHooks.sol";
 import { ERC20BrokenDecimalMock } from "../../contracts/mock/ERC20BrokenDecimalMock.sol";
 
 import "../../../src/PrizeVault.sol";


### PR DESCRIPTION
### Summary

- hooks can now pass arbitrary data between the two calls
- renamed "VaultHooks" to "PrizeHooks" since that's what everyone is calling them anyway
- the prize value passed to the `afterClaimPrizeHook` no longer includes the claim reward amount and is just the value transferred to the `prizeRecipient`