### PR TITLE
add extra precaution to maxDeposit when yield buffer is low

### DIFF
--- a/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
+++ b/test/invariant/PrizeVault/LossyPrizeVaultInvariant.t.sol
@@ -18,7 +18,8 @@ contract LossyPrizeVaultInvariant is Test {
         uint256 totalPreciseAssets = lossyVaultHarness.vault().totalPreciseAssets();
         uint256 totalDebt = lossyVaultHarness.vault().totalDebt();
         uint256 totalSupply = lossyVaultHarness.vault().totalSupply();
-        if (totalDebt > totalPreciseAssets || type(uint96).max - totalSupply == 0) {
+        uint256 yieldBuffer = lossyVaultHarness.vault().yieldBuffer();
+        if (totalDebt + yieldBuffer / 2 > totalPreciseAssets || type(uint96).max - totalSupply == 0) {
             assertEq(lossyVaultHarness.vault().maxDeposit(address(this)), 0);
         } else {
             assertGt(lossyVaultHarness.vault().maxDeposit(address(this)), 0);


### PR DESCRIPTION
The issue being addressed is an edge case in the ERC4626 compatibility of `maxDeposit` / `maxMint` when the yield buffer is low and a deposit reverts due to the `LossyDeposit` check. The 4626 spec states that a deposit MUST not revert with the value returned by maxDeposit (same with the mint function in this case), but due to potential rounding errors, it's possible that the prize vault's deposit function reverts if the yield buffer is depleted due to the rounding error.

This is *not* an issue with the deposit functionality, since it's important that we ensure there can be no lossy deposits; rather this is an issue with the `maxDeposit` function not returning zero if there is a possibility of the yield buffer being depleted.

The proposed fix adds a simple additional check to the `maxDeposit` function to ensure that the yield buffer is at least half full. If not, then `maxDeposit` will return zero, assuming that there is some possibility of a rounding error causing a reversion on deposit. Most prize vaults will only have rounding errors of 1 wei, but there have been some yield sources (specifically compound v2 and similar forks) that have additional rounding errors for 18 decimal tokens. Prize vaults for these kinds of yield sources will be configured with increased yield buffers proportional to that loss, but since there is no way for the contract to know the expected loss size, the more conservative approach for `maxDeposit` is to check if the yield buffer is at least half full.

This means that there may be a scenario where the yield buffer is less than half full and `maxDeposit` returns zero, but a deposit of some value goes through without issue. This conservative behaviour does not break the 4626 spec for `maxDeposit`.